### PR TITLE
fix(installer): handle Docker Desktop disk probe fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 FULLNODE_EXT_IP=
 FULLNODE_FQDN=
 
-NGINX_ENABLED=true
+NGINX_ENABLED=false
 
 FRPC_ENABLED=false
 # Optional legacy: if set, used for any frpc-*.toml server not set below

--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ FRPS_SERVER_ADDR_2=frankfurt.fullnode.testnet.coti.io
 FRPS_SERVER_PORT=7000
 FRPC_CUSTOM_DOMAIN=
 FRPC_AUTH_TOKEN=
+
+# After start, open on the full node host: http://127.0.0.1:8090 (operator dashboard; localhost only).

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,10 @@ FULLNODE_FQDN=
 NGINX_ENABLED=true
 
 FRPC_ENABLED=false
-FRPS_SERVER_ADDR=gateway.fullnode.testnet.coti.io
+# Optional legacy: if set, used for any frpc-*.toml server not set below
+FRPS_SERVER_ADDR=
+FRPS_SERVER_ADDR_1=virginia.fullnode.testnet.coti.io
+FRPS_SERVER_ADDR_2=frankfurt.fullnode.testnet.coti.io
 FRPS_SERVER_PORT=7000
 FRPC_CUSTOM_DOMAIN=
 FRPC_AUTH_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 FULLNODE_EXT_IP=
 FULLNODE_FQDN=
 
+NGINX_ENABLED=true
+
 FRPC_ENABLED=false
 FRPS_SERVER_ADDR=gateway.fullnode.testnet.coti.io
 FRPS_SERVER_PORT=7000

--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,5 @@ FRPS_SERVER_PORT=7000
 FRPC_CUSTOM_DOMAIN=
 FRPC_AUTH_TOKEN=
 
-# After start, open on the full node host: http://127.0.0.1:8090 (operator dashboard; localhost only).
+# After start: operator dashboard at http://127.0.0.1:8090 on the host.
+# With Nginx TLS or FRPC, use path /operator/ on your HTTPS host (see install output).

--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,5 @@ FRPS_SERVER_ADDR_2=frankfurt.fullnode.testnet.coti.io
 FRPS_SERVER_PORT=7000
 FRPC_CUSTOM_DOMAIN=
 FRPC_AUTH_TOKEN=
+# Host TCP port mapped to the node's JSON-RPC (inside the container this stays 8545).
 COTI_FULL_NODE_RPC_LOCAL_PORT=8545

--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,6 @@ NGINX_ENABLED=true
 FRPC_ENABLED=false
 FRPS_SERVER_ADDR=gateway.fullnode.testnet.coti.io
 FRPS_SERVER_PORT=7000
-FRPC_PROXY_NAME=rpc-your.node.fullnode.testnet.coti.io
 FRPC_CUSTOM_DOMAIN=
 FRPC_AUTH_TOKEN=
 COTI_FULL_NODE_RPC_LOCAL_PORT=8545

--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,3 @@ FRPS_SERVER_ADDR_2=frankfurt.fullnode.testnet.coti.io
 FRPS_SERVER_PORT=7000
 FRPC_CUSTOM_DOMAIN=
 FRPC_AUTH_TOKEN=
-# Host TCP port mapped to the node's JSON-RPC (inside the container this stays 8545).
-COTI_FULL_NODE_RPC_LOCAL_PORT=8545

--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ The stack can run an FRP client (`frpc`) container that creates an outbound-only
 - Gateway-side routing can forward external requests (for example `https://<node-id>.fullnode.testnet.coti.io/rpc`) through FRPS to your FRPC client, then to the local full-node RPC endpoint.
 
 Relevant environment variables are documented in `.env.example`.
+
+### Operator status page
+
+After `./start_coti-full-node.sh`, a small **local** web dashboard helps non-technical operators see whether the node is running, has peers, is syncing, and (when configured) whether DNS/HTTPS or the FRPC gateway look healthy. On the machine where Docker runs, open [http://127.0.0.1:8090](http://127.0.0.1:8090). It is bound to localhost only and auto-refreshes about every 15 seconds.
+
+If you manage the server over SSH, use port forwarding, for example: `ssh -L 8090:127.0.0.1:8090 user@your-node` then open `http://127.0.0.1:8090` in your desktop browser.

--- a/cleanup_coti-full-node.sh
+++ b/cleanup_coti-full-node.sh
@@ -24,10 +24,14 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DIR="$SCRIPT_DIR"
 DOMAIN=""
-if [ -f "$DIR/.env" ]; then
+if [ -f "$DIR/installer.env" ] || [ -f "$DIR/.env" ]; then
     set -a
-    source "$DIR/.env"
-    source "$DIR/installer.env"
+    # shellcheck source=/dev/null
+    [ -f "$DIR/installer.env" ] && . "$DIR/installer.env"
+    # shellcheck source=/dev/null
+    [ -f "$DIR/.env" ] && . "$DIR/.env"
+    DOCKER_FULL_NODE_IMAGE_VERSION="${IMAGE:-${DOCKER_FULL_NODE_IMAGE_VERSION:-1.2.0}}"
+    export DOCKER_FULL_NODE_IMAGE_VERSION
     set +a
     DOMAIN="${FULLNODE_FQDN:-}"
 fi

--- a/cleanup_coti-full-node.sh
+++ b/cleanup_coti-full-node.sh
@@ -47,11 +47,10 @@ if [[ ! "$CONFIRM" =~ ^[yY] ]]; then
     exit 1
 fi
 
-# Stop and remove containers
+# Stop and remove containers (all profiles) and named volumes (e.g. chain data)
 if [ -f "$DIR/docker-compose.yml" ]; then
-    echo "--> Stopping Docker containers..."
-    (cd "$DIR" && $DC --profile setup down 2>/dev/null || true)
-    (cd "$DIR" && $DC down 2>/dev/null || true)
+    echo "--> Stopping Docker containers and project volumes..."
+    (cd "$DIR" && $DC --profile frpc --profile proxy-nginx --profile setup down -v 2>/dev/null || true)
 fi
 
 # Remove cloned repo
@@ -68,5 +67,6 @@ fi
 
 echo ""
 echo "Done. Run install_coti-full-node.sh again to test from scratch."
-echo "Example:"
+echo "Example (Linux / macOS / Windows WSL on Ubuntu 24.04):"
 echo '  curl -sL https://fullnode.testnet.coti.io | sudo bash -s -- "0x..." "your.domain"'
+echo "On WSL, install from ~/... not /mnt/c/... (Docker + Geth IPC need a Linux filesystem path)."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,29 @@ services:
         max-size: "50m"
         max-file: "5"
 
+  # Local-only status page for operators (open http://127.0.0.1:8090 on the host).
+  coti-testnet-operator-dashboard:
+    build:
+      context: ./operator-dashboard
+    container_name: coti-testnet-operator-dashboard
+    restart: unless-stopped
+    depends_on:
+      coti-testnet-full-node:
+        condition: service_started
+    ports:
+      - "127.0.0.1:8090:8090"
+    environment:
+      LISTEN_PORT: "8090"
+      RPC_URL: http://coti-testnet-full-node:8545
+      FULLNODE_FQDN: ${FULLNODE_FQDN:-}
+      FULLNODE_EXT_IP: ${FULLNODE_EXT_IP:-}
+      NGINX_ENABLED: ${NGINX_ENABLED:-false}
+      FRPC_ENABLED: ${FRPC_ENABLED:-false}
+      FRPC_CUSTOM_DOMAIN: ${FRPC_CUSTOM_DOMAIN:-}
+      FRPS_SERVER_ADDR: ${FRPS_SERVER_ADDR:-}
+      FRPS_SERVER_ADDR_1: ${FRPS_SERVER_ADDR_1:-virginia.fullnode.testnet.coti.io}
+      FRPS_SERVER_PORT: ${FRPS_SERVER_PORT:-7000}
+
   frpc-1:
     image: fatedier/frpc:v0.61.2
     container_name: coti-testnet-frpc-1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       coti-testnet-full-node-genesis:
         condition: service_completed_successfully
     volumes:
-      - coti-execution-data:/execution
+      - coti-testnet-execution-data:/execution
       - ./nodekey:/execution/geth/nodekey
     logging:
       driver: "json-file"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - --bootnodes=enode://8c14ae1db71cc9796bf04cf3cc5508291621bc8b9c4c80d4d7b79d8e4b33eadcfc2298242362443fd1317c5ac887dae8e8fe9c551d7792f2bc2e7177978f730a@147.135.77.48:7400,enode://820748e65666a7444199808ecbe80f4133fa9faa7618520eb6577466336daef7aa40910a2d03dd93766ccb7b93fecdfd1a9ff32e01217235fddc3c990928fa16@63.176.21.19:7400
       - --nat=extip:${FULLNODE_EXT_IP}
     ports:
-      - "${COTI_FULL_NODE_RPC_LOCAL_PORT:-8545}:8545"
+      - "8545:8545"
       - 8546:8546
       - 7400:7400
       - 7400:7400/udp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,8 @@
+# Chain data uses a named volume so Geth can create geth.ipc (Unix socket). Bind-mounting
+# ./execution from WSL /mnt/c/... fails with "bind: operation not supported" for IPC.
+volumes:
+  coti-execution-data:
+
 services:
   # Sets up the genesis configuration for the go-ethereum client from a JSON file.
   coti-testnet-full-node-genesis:
@@ -5,7 +10,7 @@ services:
     container_name: coti-testnet-full-node-genesis
     command: --datadir=/execution init /coti-genesis/genesis.json
     volumes:
-      - ./execution/:/execution
+      - coti-execution-data:/execution
     logging:
       driver: "json-file"
       options:
@@ -54,7 +59,7 @@ services:
       coti-testnet-full-node-genesis:
         condition: service_completed_successfully
     volumes:
-      - ./execution/:/execution/
+      - coti-execution-data:/execution
       - ./nodekey:/execution/geth/nodekey
     logging:
       driver: "json-file"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,10 @@ services:
     profiles:
       - frpc
     depends_on:
-      - coti-testnet-full-node
+      coti-testnet-full-node:
+        condition: service_started
+      coti-testnet-operator-dashboard:
+        condition: service_started
     command:
       - -c
       - /etc/frp/frpc.toml
@@ -112,7 +115,10 @@ services:
     profiles:
       - frpc
     depends_on:
-      - coti-testnet-full-node
+      coti-testnet-full-node:
+        condition: service_started
+      coti-testnet-operator-dashboard:
+        condition: service_started
     command:
       - -c
       - /etc/frp/frpc.toml
@@ -136,6 +142,11 @@ services:
     container_name: nginx
     profiles:
       - proxy-nginx
+    depends_on:
+      coti-testnet-full-node:
+        condition: service_started
+      coti-testnet-operator-dashboard:
+        condition: service_started
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - --bootnodes=enode://8c14ae1db71cc9796bf04cf3cc5508291621bc8b9c4c80d4d7b79d8e4b33eadcfc2298242362443fd1317c5ac887dae8e8fe9c551d7792f2bc2e7177978f730a@147.135.77.48:7400,enode://820748e65666a7444199808ecbe80f4133fa9faa7618520eb6577466336daef7aa40910a2d03dd93766ccb7b93fecdfd1a9ff32e01217235fddc3c990928fa16@63.176.21.19:7400
       - --nat=extip:${FULLNODE_EXT_IP}
     ports:
-      - 8545:8545
+      - "${COTI_FULL_NODE_RPC_LOCAL_PORT:-8545}:8545"
       - 8546:8546
       - 7400:7400
       - 7400:7400/udp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,9 +62,9 @@ services:
         max-size: "50m"
         max-file: "5"
 
-  frpc:
+  frpc-1:
     image: fatedier/frpc:v0.61.2
-    container_name: coti-testnet-frpc
+    container_name: coti-testnet-frpc-1
     restart: unless-stopped
     profiles:
       - frpc
@@ -74,7 +74,21 @@ services:
       - -c
       - /etc/frp/frpc.toml
     volumes:
-      - ./frpc.toml:/etc/frp/frpc.toml:ro
+      - ./frpc-1.toml:/etc/frp/frpc.toml:ro
+
+  frpc-2:
+    image: fatedier/frpc:v0.61.2
+    container_name: coti-testnet-frpc-2
+    restart: unless-stopped
+    profiles:
+      - frpc
+    depends_on:
+      - coti-testnet-full-node
+    command:
+      - -c
+      - /etc/frp/frpc.toml
+    volumes:
+      - ./frpc-2.toml:/etc/frp/frpc.toml:ro
 
   # Temporary Nginx for SSL setup only (Certbot ACME challenge). Use: docker-compose --profile setup up -d nginx-init
   nginx-init:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 # Chain data uses a named volume so Geth can create geth.ipc (Unix socket). Bind-mounting
 # ./execution from WSL /mnt/c/... fails with "bind: operation not supported" for IPC.
+# Volume name is testnet-specific so a mainnet stack can use a separate volume (e.g. coti-mainnet-execution-data).
 volumes:
-  coti-execution-data:
+  coti-testnet-execution-data:
 
 services:
   # Sets up the genesis configuration for the go-ethereum client from a JSON file.
@@ -10,7 +11,7 @@ services:
     container_name: coti-testnet-full-node-genesis
     command: --datadir=/execution init /coti-genesis/genesis.json
     volumes:
-      - coti-execution-data:/execution
+      - coti-testnet-execution-data:/execution
     logging:
       driver: "json-file"
       options:

--- a/frpc-1.toml
+++ b/frpc-1.toml
@@ -1,0 +1,9 @@
+serverAddr = "virginia.fullnode.testnet.coti.io"
+serverPort = 7000
+
+[[proxies]]
+name = "replace-me.fullnode.testnet.coti.io"
+type = "http"
+localIP = "coti-testnet-full-node"
+localPort = 8545
+customDomains = ["replace-me.fullnode.testnet.coti.io"]

--- a/frpc-1.toml
+++ b/frpc-1.toml
@@ -2,8 +2,25 @@ serverAddr = "virginia.fullnode.testnet.coti.io"
 serverPort = 7000
 
 [[proxies]]
-name = "replace-me.fullnode.testnet.coti.io"
+name = "replace-me.fullnode.testnet.coti.io-rpc"
 type = "http"
 localIP = "coti-testnet-full-node"
 localPort = 8545
 customDomains = ["replace-me.fullnode.testnet.coti.io"]
+locations = ["/rpc"]
+
+[[proxies]]
+name = "replace-me.fullnode.testnet.coti.io-ws"
+type = "http"
+localIP = "coti-testnet-full-node"
+localPort = 8546
+customDomains = ["replace-me.fullnode.testnet.coti.io"]
+locations = ["/ws"]
+
+[[proxies]]
+name = "replace-me.fullnode.testnet.coti.io-operator"
+type = "http"
+localIP = "coti-testnet-operator-dashboard"
+localPort = 8090
+customDomains = ["replace-me.fullnode.testnet.coti.io"]
+locations = ["/operator"]

--- a/frpc-2.toml
+++ b/frpc-2.toml
@@ -2,8 +2,25 @@ serverAddr = "frankfurt.fullnode.testnet.coti.io"
 serverPort = 7000
 
 [[proxies]]
-name = "replace-me.fullnode.testnet.coti.io"
+name = "replace-me.fullnode.testnet.coti.io-rpc"
 type = "http"
 localIP = "coti-testnet-full-node"
 localPort = 8545
 customDomains = ["replace-me.fullnode.testnet.coti.io"]
+locations = ["/rpc"]
+
+[[proxies]]
+name = "replace-me.fullnode.testnet.coti.io-ws"
+type = "http"
+localIP = "coti-testnet-full-node"
+localPort = 8546
+customDomains = ["replace-me.fullnode.testnet.coti.io"]
+locations = ["/ws"]
+
+[[proxies]]
+name = "replace-me.fullnode.testnet.coti.io-operator"
+type = "http"
+localIP = "coti-testnet-operator-dashboard"
+localPort = 8090
+customDomains = ["replace-me.fullnode.testnet.coti.io"]
+locations = ["/operator"]

--- a/frpc-2.toml
+++ b/frpc-2.toml
@@ -1,4 +1,4 @@
-serverAddr = "gateway.fullnode.testnet.coti.io"
+serverAddr = "frankfurt.fullnode.testnet.coti.io"
 serverPort = 7000
 
 [[proxies]]

--- a/frpc.toml
+++ b/frpc.toml
@@ -2,7 +2,7 @@ serverAddr = "gateway.fullnode.testnet.coti.io"
 serverPort = 7000
 
 [[proxies]]
-name = "rpc-replace-me.fullnode.testnet.coti.io"
+name = "replace-me.fullnode.testnet.coti.io"
 type = "http"
 localIP = "coti-testnet-full-node"
 localPort = 8545

--- a/install_coti-full-node-mac.sh
+++ b/install_coti-full-node-mac.sh
@@ -1,0 +1,568 @@
+#!/bin/bash
+# COTI Full Node — macOS installer (standalone; use install_coti-full-node.sh on Ubuntu/WSL).
+set -e
+
+# --- Terminal styling (no-op when stdout is not a TTY) ---
+if [ -t 1 ] && command -v tput >/dev/null 2>&1; then
+    _B=$(tput bold 2>/dev/null || true)
+    _D=$(tput dim 2>/dev/null || true)
+    _U=$(tput smul 2>/dev/null || true)
+    _R=$(tput sgr0 2>/dev/null || true)
+    _C=$(tput setaf 6 2>/dev/null || true)
+    _G=$(tput setaf 2 2>/dev/null || true)
+    _Y=$(tput setaf 3 2>/dev/null || true)
+else
+    _B="" _D="" _U="" _R="" _C="" _G="" _Y=""
+fi
+
+_w() { printf '%s\n' "$*"; }
+_banner_line() { printf '%s\n' "${_C}${_B}$*${_R}"; }
+_div() { printf '%s\n' "${_D}────────────────────────────────────────────────────${_R}"; }
+
+info() { printf '%s\n' "${_C}→${_R} $*"; }
+ok() { printf '%s\n' "${_G}✓${_R} $*"; }
+
+# macOS: true if something is listening on TCP port $1
+_tcp_port_in_use() {
+    local port="$1"
+    if command -v lsof >/dev/null 2>&1; then
+        lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+    else
+        return 1
+    fi
+}
+
+print_welcome() {
+    _div
+    _banner_line "  COTI Full Node — macOS installer"
+    _div
+    _w ""
+    _w "${_B}Planned steps${_R}"
+    _w "  1. OS validation (macOS)"
+    _w "  2. Validate inputs (private key, FQDN)"
+    _w "  3. Check Docker + install tools (Homebrew) if needed"
+    _w "  4. Clone repository and prepare directory"
+    _w "  5. Generate .env and node identity"
+    _w "  6. Optional: Nginx + Let's Encrypt (${_Y}off by default${_R}; ${_U}--with-nginx${_R})"
+    _w "  7. Optional: FRPC (${_Y}off by default${_R}; ${_U}--with-frp${_R} / ${_U}--frpc-enabled=true${_R})"
+    _w "  8. Start the stack"
+    _w ""
+    _div
+}
+
+print_requirements() {
+    _div
+    _banner_line "  Requirements (macOS)"
+    _div
+    _w "  • macOS with ${_B}Docker Desktop${_R} or another Docker engine (Colima, etc.); \`docker\` and \`docker compose\` must work"
+    _w "  • ${_B}Homebrew${_R} (https://brew.sh) — used to install jq, certbot (if Nginx), git if missing"
+    _w "  • ${_B}Nginx + TLS:${_R} certificates and Certbot state live under ${_U}./nginx/letsencrypt*${_R} in the clone (no elevated privileges in this script)"
+    _w "  • Free disk: ${DISK_SPACE_REQUIRED} GB in the install directory"
+    _w "  • Port 7400 must be free on the host for published P2P (see docker-compose)"
+    _w "  • ${_B}With Nginx/SSL:${_R} host ports 80 and 443 free"
+    _w "  • ${_B}With --with-frp${_R}: COTI wizard tunnel — no host Nginx; inbound 80/443/7400 not required on your router"
+    _w ""
+    _div
+}
+
+FULLNODE_INSTALLER_MAC_URL="${FULLNODE_INSTALLER_MAC_URL:-https://raw.githubusercontent.com/coti-io/coti-full-node/coti-testnet/install_coti-full-node-mac.sh}"
+
+print_install_curl_examples() {
+    _w "macOS (example; set branch to match your network):"
+    _w "  curl -sL https://raw.githubusercontent.com/coti-io/coti-full-node/development/install_coti-full-node-mac.sh \\"
+    _w "    | env CLONE_BRANCH=development bash -s -- \"0x...\" \"your.domain\" --with-frp"
+    _w ""
+    _w "Default URL constant (override when mirroring): ${FULLNODE_INSTALLER_MAC_URL}"
+}
+
+# --- 0a. OS: Darwin only ---
+if [ "$(uname -s)" != "Darwin" ]; then
+    printf '%s\n' "${_Y}ERROR:${_R} This script is for macOS only."
+    _w "On Ubuntu or WSL, use install_coti-full-node.sh (with sudo)."
+    exit 1
+fi
+
+# --- 0b. Do not run as root (Homebrew; Docker Desktop) ---
+if [ "$(id -u)" -eq 0 ]; then
+    printf '%s\n' "${_Y}ERROR:${_R} Do not run this macOS installer as root or with sudo."
+    _w ""
+    print_install_curl_examples
+    exit 1
+fi
+
+print_welcome
+read -r -p "Press Enter to continue, or Ctrl+C to abort " < /dev/tty || true
+_w ""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+INSTALLER_ENV_FILE="$SCRIPT_DIR/installer.env"
+if [ -f "$INSTALLER_ENV_FILE" ]; then
+    # shellcheck source=/dev/null
+    . "$INSTALLER_ENV_FILE"
+fi
+
+: "${DISK_SPACE_REQUIRED:=40}"
+
+print_requirements
+read -r -p "Press Enter to continue, or Ctrl+C to abort " < /dev/tty || true
+_w ""
+
+_FRPS_SERVER_ADDR_1_FROM_ENV=false
+_FRPS_SERVER_ADDR_2_FROM_ENV=false
+if declare -p FRPS_SERVER_ADDR_1 >/dev/null 2>&1; then
+    _FRPS_SERVER_ADDR_1_FROM_ENV=true
+fi
+if declare -p FRPS_SERVER_ADDR_2 >/dev/null 2>&1; then
+    _FRPS_SERVER_ADDR_2_FROM_ENV=true
+fi
+
+: "${DOCKER_FULL_NODE_IMAGE_VERSION:=1.2.0}"
+DOCKER_FULL_NODE_IMAGE_VERSION="${IMAGE:-$DOCKER_FULL_NODE_IMAGE_VERSION}"
+: "${CLONE_BRANCH:=coti-testnet}"
+: "${NETWORK:=testnet}"
+: "${NGINX_ENABLED:=false}"
+: "${FRPC_ENABLED:=false}"
+: "${FRPS_SERVER_ADDR:=}"
+: "${FRPS_SERVER_ADDR_1:=virginia.fullnode.testnet.coti.io}"
+: "${FRPS_SERVER_ADDR_2:=frankfurt.fullnode.testnet.coti.io}"
+: "${FRPS_SERVER_PORT:=7000}"
+: "${FRPC_CUSTOM_DOMAIN:=}"
+: "${FRPC_AUTH_TOKEN:=}"
+: "${COTI_FULL_NODE_RPC_LOCAL_PORT:=8545}"
+
+FRPS_SERVER_ADDR_1_EXPLICIT=false
+FRPS_SERVER_ADDR_2_EXPLICIT=false
+COTI_TUNNEL_INSTALL=false
+POSITIONAL=()
+for arg in "$@"; do
+    case "$arg" in
+        --without-nginx)
+            NGINX_ENABLED=false
+            ;;
+        --with-nginx)
+            NGINX_ENABLED=true
+            COTI_TUNNEL_INSTALL=false
+            ;;
+        --nginx-enabled=*)
+            NGINX_ENABLED="${arg#*=}"
+            if [[ "$NGINX_ENABLED" == "true" ]]; then
+                COTI_TUNNEL_INSTALL=false
+            fi
+            ;;
+        --staging)
+            CERTBOT_STAGING=true
+            ;;
+        --with-frp)
+            FRPC_ENABLED=true
+            NGINX_ENABLED=false
+            COTI_TUNNEL_INSTALL=true
+            ;;
+        --without-frp)
+            FRPC_ENABLED=false
+            COTI_TUNNEL_INSTALL=false
+            ;;
+        --frpc-enabled=*)
+            FRPC_ENABLED="${arg#*=}"
+            if [[ "$FRPC_ENABLED" != "true" ]]; then
+                COTI_TUNNEL_INSTALL=false
+            fi
+            ;;
+        --frpc-custom-domain=*)
+            FRPC_CUSTOM_DOMAIN="${arg#*=}"
+            ;;
+        --frpc-auth-token=*)
+            FRPC_AUTH_TOKEN="${arg#*=}"
+            ;;
+        --frps-server-addr=*)
+            FRPS_SERVER_ADDR="${arg#*=}"
+            ;;
+        --frps-server-addr-1=*)
+            FRPS_SERVER_ADDR_1="${arg#*=}"
+            FRPS_SERVER_ADDR_1_EXPLICIT=true
+            ;;
+        --frps-server-addr-2=*)
+            FRPS_SERVER_ADDR_2="${arg#*=}"
+            FRPS_SERVER_ADDR_2_EXPLICIT=true
+            ;;
+        --frps-server-port=*)
+            FRPS_SERVER_PORT="${arg#*=}"
+            ;;
+        *)
+            POSITIONAL+=("$arg")
+            ;;
+    esac
+done
+
+PK="${POSITIONAL[0]:-}"
+FQDN="${POSITIONAL[1]:-}"
+
+if [[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]] && [[ "$FRPC_ENABLED" != "true" ]]; then
+    printf '%s\n' "${_Y}ERROR:${_R} COTI tunnel install requires FRPC enabled (use ${_U}--with-frp${_R})."
+    exit 1
+fi
+
+if [ -n "${FRPS_SERVER_ADDR:-}" ]; then
+    if [[ "$FRPS_SERVER_ADDR_1_EXPLICIT" != "true" ]] && [[ "$_FRPS_SERVER_ADDR_1_FROM_ENV" != "true" ]]; then
+        FRPS_SERVER_ADDR_1="$FRPS_SERVER_ADDR"
+    fi
+    if [[ "$FRPS_SERVER_ADDR_2_EXPLICIT" != "true" ]] && [[ "$_FRPS_SERVER_ADDR_2_FROM_ENV" != "true" ]]; then
+        FRPS_SERVER_ADDR_2="$FRPS_SERVER_ADDR"
+    fi
+fi
+
+_div
+_banner_line "  Installing COTI Full Node (macOS)"
+_div
+_w ""
+
+# --- 0c. Optional macOS version notice ---
+MACOS_VER="$(sw_vers -productVersion 2>/dev/null || printf '%s' "unknown")"
+info "Detected macOS ${MACOS_VER}"
+
+# --- 1. VALIDATE REQUIRED INPUTS ---
+if [ -z "$FQDN" ] || [ -z "$PK" ]; then
+    printf '%s\n' "${_Y}ERROR:${_R} Private key and FQDN are required."
+    _w ""
+    print_install_curl_examples
+    _w ""
+    _w "With Nginx + Let's Encrypt: append ${_U}--with-nginx${_R}"
+    _w "Wizard tunnel: ${_U}--with-frp${_R}"
+    exit 1
+fi
+
+PK_CLEAN="${PK#0x}"
+
+if [[ ! "$PK_CLEAN" =~ ^[0-9a-fA-F]{64}$ ]]; then
+    printf '%s\n' "${_Y}ERROR:${_R} Private key must be 64 hex characters (32 bytes), with optional 0x prefix."
+    printf '%s\n' "Got ${#PK_CLEAN} hex characters after stripping 0x."
+    exit 1
+fi
+
+if [[ ! "$FQDN" =~ ^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$ ]] || [ "${#FQDN}" -gt 253 ]; then
+    printf '%s\n' "${_Y}ERROR:${_R} FQDN must be a valid hostname (letters, numbers, hyphens, dots; 1–253 chars)."
+    _w "Example: node1.fullnode.testnet.coti.io"
+    exit 1
+fi
+
+if [[ ! "$NGINX_ENABLED" =~ ^(true|false)$ ]]; then
+    printf '%s\n' "${_Y}ERROR:${_R} NGINX_ENABLED must be 'true' or 'false'."
+    exit 1
+fi
+
+if [[ ! "$FRPC_ENABLED" =~ ^(true|false)$ ]]; then
+    printf '%s\n' "${_Y}ERROR:${_R} FRPC_ENABLED must be 'true' or 'false'."
+    exit 1
+fi
+
+if [[ "$FRPC_ENABLED" == "true" ]] && [ -z "$FRPC_CUSTOM_DOMAIN" ]; then
+    FRPC_CUSTOM_DOMAIN="$FQDN"
+fi
+
+if [[ ! "$FRPS_SERVER_PORT" =~ ^[0-9]+$ ]] || [ "$FRPS_SERVER_PORT" -lt 1 ] || [ "$FRPS_SERVER_PORT" -gt 65535 ]; then
+    printf '%s\n' "${_Y}ERROR:${_R} FRPS_SERVER_PORT must be a valid TCP port (1–65535)."
+    exit 1
+fi
+
+if [[ ! "$COTI_FULL_NODE_RPC_LOCAL_PORT" =~ ^[0-9]+$ ]] || [ "$COTI_FULL_NODE_RPC_LOCAL_PORT" -lt 1 ] || [ "$COTI_FULL_NODE_RPC_LOCAL_PORT" -gt 65535 ]; then
+    printf '%s\n' "${_Y}ERROR:${_R} COTI_FULL_NODE_RPC_LOCAL_PORT must be a valid TCP port (1–65535)."
+    exit 1
+fi
+
+info "Install mode: Nginx/SSL ${_B}${NGINX_ENABLED}${_R} · FRPC relay ${_B}${FRPC_ENABLED}${_R}$([[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]] && printf ' · %s' "${_B}COTI tunnel (wizard)${_R}")"
+_w ""
+
+INSTALL_DIR="$(pwd)"
+if [ ! -w "$INSTALL_DIR" ]; then
+    printf '%s\n' "${_Y}ERROR:${_R} Cannot write to current directory ($INSTALL_DIR)."
+    _w "Run from a writable directory (for example cd ~ && mkdir coti && cd coti)."
+    exit 1
+fi
+
+REQUIRED_KB=$((DISK_SPACE_REQUIRED * 1024 * 1024))
+AVAIL_KB=$(df -k "$INSTALL_DIR" | awk 'NR==2 {print $4}')
+if [ -z "$AVAIL_KB" ] || [ "$AVAIL_KB" -lt "$REQUIRED_KB" ]; then
+    if [ -n "$AVAIL_KB" ]; then
+        AVAIL_GB=$((AVAIL_KB / 1024 / 1024))
+        printf '%s\n' "${_Y}ERROR:${_R} Need at least ${DISK_SPACE_REQUIRED} GB free in $INSTALL_DIR (about ${AVAIL_GB} GB available)."
+    else
+        printf '%s\n' "${_Y}ERROR:${_R} Could not read free disk space for $INSTALL_DIR."
+    fi
+    exit 1
+fi
+
+if [[ "$NGINX_ENABLED" == "true" ]]; then
+    for port in 80 443; do
+        if _tcp_port_in_use "$port"; then
+            printf '%s\n' "${_Y}ERROR:${_R} Port $port is in use. Nginx needs 80 and 443 free on the Mac."
+            exit 1
+        fi
+    done
+fi
+
+if _tcp_port_in_use 7400; then
+    printf '%s\n' "${_Y}ERROR:${_R} Port 7400 is already in use on the Mac."
+    exit 1
+fi
+
+# macOS: skip Linux ufw/iptables checks
+
+# --- 2. DOCKER + HOMEBREW DEPENDENCIES ---
+if ! command -v docker >/dev/null 2>&1; then
+    printf '%s\n' "${_Y}ERROR:${_R} Docker is not in PATH."
+    _w "Install Docker Desktop (https://www.docker.com/products/docker-desktop/) or Colima, then re-run."
+    exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    printf '%s\n' "${_Y}ERROR:${_R} Docker daemon is not reachable. Start Docker Desktop (or your engine) and try again."
+    exit 1
+fi
+
+if docker compose version >/dev/null 2>&1; then
+    DC="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+    DC="docker-compose"
+else
+    printf '%s\n' "${_Y}ERROR:${_R} Neither \`docker compose\` nor \`docker-compose\` is available."
+    _w "Update Docker Desktop or install the Compose plugin / standalone docker-compose."
+    exit 1
+fi
+
+if ! command -v brew >/dev/null 2>&1; then
+    printf '%s\n' "${_Y}ERROR:${_R} Homebrew not found (brew)."
+    _w "Install from https://brew.sh then ensure brew is on your PATH and re-run."
+    exit 1
+fi
+
+_brew_install_if_missing() {
+    local formula="$1"
+    if brew list --formula "$formula" >/dev/null 2>&1; then
+        return 0
+    fi
+    info "Installing $formula via Homebrew..."
+    brew install "$formula"
+}
+
+if ! command -v git >/dev/null 2>&1; then
+    _brew_install_if_missing git
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    _brew_install_if_missing jq
+fi
+if [[ "$NGINX_ENABLED" == "true" ]]; then
+    if ! command -v certbot >/dev/null 2>&1; then
+        _brew_install_if_missing certbot
+    fi
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+    printf '%s\n' "${_Y}ERROR:${_R} curl not found."
+    exit 1
+fi
+
+# --- 3. CLONE/PREPARE DIRECTORY ---
+if [ -f "docker-compose.yml" ] || [ -d "coti-full-node" ]; then
+    printf '%s\n' "${_Y}ERROR:${_R} Current directory is not clean for a fresh install."
+    _w "  • docker-compose.yml present, or"
+    _w "  • coti-full-node/ already exists"
+    _w "Use an empty directory and run again."
+    exit 1
+fi
+
+info "Cloning coti-full-node (${CLONE_BRANCH})..."
+git clone -b "$CLONE_BRANCH" https://github.com/coti-io/coti-full-node.git
+cd coti-full-node
+
+info "Writing installer.env (installation metadata)..."
+cat <<EOF > installer.env
+# Installation / packaging defaults for this checkout (not host-specific).
+# Per-host settings are in .env (sourced after this file by start/stop scripts).
+#
+# Bump DOCKER_FULL_NODE_IMAGE_VERSION (or set IMAGE=) to upgrade the node image, then run ./start_coti-full-node.sh
+
+DISK_SPACE_REQUIRED=${DISK_SPACE_REQUIRED}
+DOCKER_FULL_NODE_IMAGE_VERSION=${DOCKER_FULL_NODE_IMAGE_VERSION}
+CLONE_BRANCH=${CLONE_BRANCH}
+NETWORK=${NETWORK}
+EOF
+
+info "Writing .env..."
+if ! EXT_IP=$(curl -fsS --connect-timeout 10 --max-time 20 https://api.ipify.org); then
+    printf '%s\n' "${_Y}ERROR:${_R} Could not detect public IP (api.ipify.org). Check outbound HTTPS and re-run."
+    exit 1
+fi
+if [ -z "$EXT_IP" ]; then
+    printf '%s\n' "${_Y}ERROR:${_R} Public IP lookup returned an empty response."
+    exit 1
+fi
+
+cat <<EOF > .env
+FULLNODE_EXT_IP=$EXT_IP
+FULLNODE_FQDN=$FQDN
+NGINX_ENABLED=$NGINX_ENABLED
+FRPC_ENABLED=$FRPC_ENABLED
+FRPS_SERVER_ADDR=$FRPS_SERVER_ADDR
+FRPS_SERVER_ADDR_1=$FRPS_SERVER_ADDR_1
+FRPS_SERVER_ADDR_2=$FRPS_SERVER_ADDR_2
+FRPS_SERVER_PORT=$FRPS_SERVER_PORT
+FRPC_CUSTOM_DOMAIN=$FRPC_CUSTOM_DOMAIN
+FRPC_AUTH_TOKEN=$FRPC_AUTH_TOKEN
+COTI_FULL_NODE_RPC_LOCAL_PORT=$COTI_FULL_NODE_RPC_LOCAL_PORT
+EOF
+
+info "Writing node key..."
+echo -n "$PK_CLEAN" > ./nodekey
+
+if [[ "$FRPC_ENABLED" == "true" ]]; then
+    FRPC_AUTH_BLOCK=""
+    if [ -n "$FRPC_AUTH_TOKEN" ]; then
+        FRPC_AUTH_BLOCK=$(cat <<EOF
+auth.method = "token"
+auth.token = "$FRPC_AUTH_TOKEN"
+EOF
+)
+    fi
+
+    for _frpc_toml_pair in \
+        "frpc-1.toml:$FRPS_SERVER_ADDR_1" \
+        "frpc-2.toml:$FRPS_SERVER_ADDR_2"; do
+        _frpc_toml_file="${_frpc_toml_pair%%:*}"
+        _frpc_server_addr="${_frpc_toml_pair#*:}"
+        cat <<EOF > "./$_frpc_toml_file"
+serverAddr = "$_frpc_server_addr"
+serverPort = $FRPS_SERVER_PORT
+$FRPC_AUTH_BLOCK
+
+[[proxies]]
+name = "$FRPC_CUSTOM_DOMAIN"
+type = "http"
+localIP = "coti-${NETWORK}-full-node"
+localPort = 8545
+customDomains = ["$FRPC_CUSTOM_DOMAIN"]
+EOF
+    done
+    unset _frpc_toml_pair _frpc_toml_file _frpc_server_addr
+fi
+
+if [[ "$NGINX_ENABLED" == "true" ]]; then
+    info "Preparing Let's Encrypt HTTP-01 challenge..."
+    mkdir -p ./nginx/certbot ./nginx/sites-enabled
+    mkdir -p ./nginx/letsencrypt ./nginx/letsencrypt-work ./nginx/letsencrypt-logs
+
+    # Project-local Certbot dirs (no /etc/letsencrypt on the host). Patch compose so Nginx mounts the same tree.
+    info "Pointing docker-compose Nginx volume to ./nginx/letsencrypt (macOS installer)..."
+    sed -i '' 's|- /etc/letsencrypt:/etc/letsencrypt:ro|- ./nginx/letsencrypt:/etc/letsencrypt:ro|' docker-compose.yml
+    if ! grep -qF './nginx/letsencrypt:/etc/letsencrypt:ro' docker-compose.yml; then
+        printf '%s\n' "${_Y}ERROR:${_R} Could not set Nginx bind mount to ./nginx/letsencrypt in docker-compose.yml."
+        _w "Expected a line containing: - /etc/letsencrypt:/etc/letsencrypt:ro"
+        exit 1
+    fi
+
+    info "Starting temporary Nginx for ACME..."
+    $DC --profile setup up -d nginx-init
+
+    CERTBOT_EXTRA=""
+    if [[ "$CERTBOT_STAGING" == "true" ]]; then
+        info "Requesting certificate for $FQDN (${_Y}Let's Encrypt staging${_R} — not browser-trusted)..."
+        CERTBOT_EXTRA="--staging"
+    else
+        info "Requesting certificate for $FQDN..."
+    fi
+    _le_root="$(pwd)/nginx"
+    certbot certonly --webroot -w "$(pwd)/nginx/certbot" -d "$FQDN" $CERTBOT_EXTRA \
+        --config-dir "$_le_root/letsencrypt" \
+        --work-dir "$_le_root/letsencrypt-work" \
+        --logs-dir "$_le_root/letsencrypt-logs" \
+        --register-unsafely-without-email --agree-tos --non-interactive
+    unset _le_root
+
+    info "Stopping temporary Nginx..."
+    $DC --profile setup down
+
+    info "Writing Nginx TLS proxy config..."
+    cat <<EOF > ./nginx/sites-enabled/fullnode.conf
+
+upstream fullnode_8545 {
+    server coti-$NETWORK-full-node:8545  max_fails=3 fail_timeout=30s;
+}
+
+upstream fullnode_8546 {
+    server coti-$NETWORK-full-node:8546  max_fails=3 fail_timeout=30s;
+}
+
+upstream fullnode_6000 {
+    server coti-$NETWORK-full-node:6000  max_fails=3 fail_timeout=30s;
+}
+
+server {
+    listen 443 ssl;
+    server_name $FQDN;
+
+    ssl_certificate     /etc/letsencrypt/live/$FQDN/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$FQDN/privkey.pem;
+    ssl_session_timeout 5m;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
+    ssl_prefer_server_ciphers on;
+
+    location /ws {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host \$http_host;
+        proxy_pass http://fullnode_8546/;
+    }
+
+    location /rpc {
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_pass http://fullnode_8545/;
+    }
+
+    location /metrics {
+        proxy_set_header Host \$host;
+        proxy_pass http://fullnode_6000/debug/metrics/prometheus;
+    }
+}
+
+server {
+    listen 80;
+    server_name $FQDN;
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+    location / {
+        return 301 https://\$host\$request_uri;
+    }
+}
+EOF
+fi
+
+info "Starting the full node stack..."
+./start_coti-full-node.sh
+
+_w ""
+_div
+ok "COTI full node is starting."
+_w ""
+if [[ "$NGINX_ENABLED" != "true" ]]; then
+    _w "  • Mode: ${_B}no Nginx/SSL on this host${_R}"
+    if [[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]] && [[ "$FRPC_ENABLED" == "true" ]]; then
+        _w "  • COTI tunnel: public HTTPS/RPC at ${_B}https://${FRPC_CUSTOM_DOMAIN:-$FQDN}${_R} (edge TLS + DNS by COTI; FRPC to this node)"
+    else
+        _w "  • RPC / WS: published on host ports ${COTI_FULL_NODE_RPC_LOCAL_PORT} / 8546 (see docker-compose)"
+    fi
+else
+    _w "  • HTTPS: ${_B}https://$FQDN${_R}"
+fi
+if [[ "$FRPC_ENABLED" == "true" ]]; then
+    _w "  • FRPC: ${_B}enabled${_R} — gateways $FRPS_SERVER_ADDR_1:$FRPS_SERVER_PORT, $FRPS_SERVER_ADDR_2:$FRPS_SERVER_PORT"
+    _w "  • FRPC custom domain (proxy name): ${FRPC_CUSTOM_DOMAIN}"
+    if [[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]]; then
+        _w "  • Inbound firewall: ${_B}not required${_R} for 80/443/7400 from the internet (outbound FRP + local P2P)"
+    fi
+else
+    _w "  • FRPC: ${_D}disabled${_R} (wizard tunnel: ${_U}--with-frp${_R}; relay only: ${_U}--frpc-enabled=true${_R})"
+fi
+_w "  • Logs: ${_U}docker logs -f coti-$NETWORK-full-node${_R}"
+_div

--- a/install_coti-full-node-mac.sh
+++ b/install_coti-full-node-mac.sh
@@ -153,7 +153,6 @@ DOCKER_FULL_NODE_IMAGE_VERSION="${IMAGE:-$DOCKER_FULL_NODE_IMAGE_VERSION}"
 : "${FRPS_SERVER_PORT:=7000}"
 : "${FRPC_CUSTOM_DOMAIN:=}"
 : "${FRPC_AUTH_TOKEN:=}"
-: "${COTI_FULL_NODE_RPC_LOCAL_PORT:=8545}"
 
 FRPS_SERVER_ADDR_1_EXPLICIT=false
 FRPS_SERVER_ADDR_2_EXPLICIT=false
@@ -285,11 +284,6 @@ fi
 
 if [[ ! "$FRPS_SERVER_PORT" =~ ^[0-9]+$ ]] || [ "$FRPS_SERVER_PORT" -lt 1 ] || [ "$FRPS_SERVER_PORT" -gt 65535 ]; then
     printf '%s\n' "${_Y}ERROR:${_R} FRPS_SERVER_PORT must be a valid TCP port (1–65535)."
-    exit 1
-fi
-
-if [[ ! "$COTI_FULL_NODE_RPC_LOCAL_PORT" =~ ^[0-9]+$ ]] || [ "$COTI_FULL_NODE_RPC_LOCAL_PORT" -lt 1 ] || [ "$COTI_FULL_NODE_RPC_LOCAL_PORT" -gt 65535 ]; then
-    printf '%s\n' "${_Y}ERROR:${_R} COTI_FULL_NODE_RPC_LOCAL_PORT must be a valid TCP port (1–65535)."
     exit 1
 fi
 
@@ -438,7 +432,6 @@ FRPS_SERVER_ADDR_2=$FRPS_SERVER_ADDR_2
 FRPS_SERVER_PORT=$FRPS_SERVER_PORT
 FRPC_CUSTOM_DOMAIN=$FRPC_CUSTOM_DOMAIN
 FRPC_AUTH_TOKEN=$FRPC_AUTH_TOKEN
-COTI_FULL_NODE_RPC_LOCAL_PORT=$COTI_FULL_NODE_RPC_LOCAL_PORT
 EOF
 
 info "Writing node key..."
@@ -581,7 +574,7 @@ if [[ "$NGINX_ENABLED" != "true" ]]; then
     if [[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]] && [[ "$FRPC_ENABLED" == "true" ]]; then
         _w "  • COTI tunnel: public HTTPS/RPC at ${_B}https://${FRPC_CUSTOM_DOMAIN:-$FQDN}${_R} (edge TLS + DNS by COTI; FRPC to this node)"
     else
-        _w "  • RPC / WS: published on host ports ${COTI_FULL_NODE_RPC_LOCAL_PORT} / 8546 (see docker-compose)"
+        _w "  • RPC / WS: published on host ports 8545 / 8546 (see docker-compose)"
     fi
 else
     _w "  • HTTPS: ${_B}https://$FQDN${_R}"

--- a/install_coti-full-node-mac.sh
+++ b/install_coti-full-node-mac.sh
@@ -589,4 +589,5 @@ else
     _w "  • FRPC: ${_D}disabled${_R} (wizard tunnel: ${_U}--with-frp${_R}; relay only: ${_U}--frpc-enabled=true${_R})"
 fi
 _w "  • Logs: ${_U}docker logs -f coti-$NETWORK-full-node${_R}"
+_w "  • ${_B}Health check page${_R} (this machine): ${_U}http://127.0.0.1:8090${_R}"
 _div

--- a/install_coti-full-node-mac.sh
+++ b/install_coti-full-node-mac.sh
@@ -54,7 +54,7 @@ print_requirements() {
     _div
     _banner_line "  Requirements (macOS)"
     _div
-    _w "  • macOS with ${_B}Docker Desktop${_R} or another Docker engine (Colima, etc.); \`docker\` and \`docker compose\` must work"
+    _w "  • ${_B}Docker${_R} installed ${_B}before${_R} you run this script (this installer does not install Docker). Use Docker Desktop or Colima; \`docker\` and \`docker compose\` must work"
     _w "  • ${_B}Homebrew${_R} (https://brew.sh) — used to install jq, certbot (if Nginx), git if missing"
     _w "  • ${_B}Nginx + TLS:${_R} certificates and Certbot state live under ${_U}./nginx/letsencrypt*${_R} in the clone (no elevated privileges in this script)"
     _w "  • Free disk: ${DISK_SPACE_REQUIRED} GB in the install directory"
@@ -81,6 +81,9 @@ if [ "$(uname -s)" != "Darwin" ]; then
     _w "On Ubuntu or WSL, use install_coti-full-node.sh (with sudo)."
     exit 1
 fi
+
+# Non-interactive bash (e.g. `curl … | bash`) often inherits a minimal PATH. Docker Desktop and Homebrew install CLIs here.
+export PATH="/usr/local/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin:${HOME}/.docker/bin:${PATH}"
 
 # --- 0b. Do not run as root (Homebrew; Docker Desktop) ---
 if [ "$(id -u)" -eq 0 ]; then
@@ -308,8 +311,12 @@ fi
 
 # --- 2. DOCKER + HOMEBREW DEPENDENCIES ---
 if ! command -v docker >/dev/null 2>&1; then
-    printf '%s\n' "${_Y}ERROR:${_R} Docker is not in PATH."
-    _w "Install Docker Desktop (https://www.docker.com/products/docker-desktop/) or Colima, then re-run."
+    printf '%s\n' "${_Y}ERROR:${_R} \`docker\` not found (not on PATH)."
+    _w "This installer does ${_B}not${_R} install Docker (unlike the Ubuntu installer, which can install docker.io via apt)."
+    _w "Install Docker yourself, then re-run. Examples:"
+    _w "  • ${_B}Docker Desktop:${_R} https://www.docker.com/products/docker-desktop/ — or, with Homebrew: ${_U}brew install --cask docker${_R} then open Docker from Applications once."
+    _w "  • ${_B}Colima:${_R} ${_U}brew install colima docker${_R} then ${_U}colima start${_R}"
+    _w "If \`docker\` works in Terminal but failed here, PATH was too small for a piped script; this script already prepends common install locations."
     exit 1
 fi
 

--- a/install_coti-full-node-mac.sh
+++ b/install_coti-full-node-mac.sh
@@ -126,7 +126,7 @@ if [ -f "$INSTALLER_ENV_FILE" ]; then
     . "$INSTALLER_ENV_FILE"
 fi
 
-: "${DISK_SPACE_REQUIRED:=40}"
+: "${DISK_SPACE_REQUIRED:=90}"
 
 print_requirements
 read -r -p "Press Enter to continue, or Ctrl+C to abort " < /dev/tty || true

--- a/install_coti-full-node-mac.sh
+++ b/install_coti-full-node-mac.sh
@@ -22,6 +22,28 @@ _div() { printf '%s\n' "${_D}─────────────────
 info() { printf '%s\n' "${_C}→${_R} $*"; }
 ok() { printf '%s\n' "${_G}✓${_R} $*"; }
 
+# Free KiB on the filesystem backing Docker images/volumes (named chain data volumes live here).
+_docker_engine_avail_kb() {
+    local root kb
+    docker info >/dev/null 2>&1 || return 1
+    root=$(docker info -f '{{.DockerRootDir}}' 2>/dev/null) || return 1
+    [ -n "$root" ] || return 1
+    root="${root%/}"
+    kb=$(docker run --rm -v /:/host:ro alpine:3.20 sh -c "df -Pk '/host${root}' 2>/dev/null | awk 'NR==2{print \$4}'" 2>/dev/null || true)
+    if [ -n "$kb" ] && [ "$kb" -ge 1 ] 2>/dev/null; then
+        printf '%s\n' "$kb"
+        return 0
+    fi
+    if [ -e "$root" ]; then
+        kb=$(df -k "$root" 2>/dev/null | awk 'NR==2{print $4}')
+        if [ -n "$kb" ] && [ "$kb" -ge 1 ] 2>/dev/null; then
+            printf '%s\n' "$kb"
+            return 0
+        fi
+    fi
+    return 1
+}
+
 # macOS: true if something is listening on TCP port $1
 _tcp_port_in_use() {
     local port="$1"
@@ -57,7 +79,7 @@ print_requirements() {
     _w "  • ${_B}Docker${_R} installed ${_B}before${_R} you run this script (this installer does not install Docker). Use Docker Desktop or Colima; \`docker\` and \`docker compose\` must work"
     _w "  • ${_B}Homebrew${_R} (https://brew.sh) — used to install jq, certbot (if Nginx), git if missing"
     _w "  • ${_B}Nginx + TLS:${_R} certificates and Certbot state live under ${_U}./nginx/letsencrypt*${_R} in the clone (no elevated privileges in this script)"
-    _w "  • Free disk: ${DISK_SPACE_REQUIRED} GB in the install directory"
+    _w "  • Free disk: ${DISK_SPACE_REQUIRED} GB where Docker stores images/volumes (chain data uses a named volume, not the project folder)"
     _w "  • Port 7400 must be free on the host for published P2P (see docker-compose)"
     _w "  • ${_B}With Nginx/SSL:${_R} host ports 80 and 443 free"
     _w "  • ${_B}With --with-frp${_R}: COTI wizard tunnel — no host Nginx; inbound 80/443/7400 not required on your router"
@@ -281,18 +303,6 @@ if [ ! -w "$INSTALL_DIR" ]; then
     exit 1
 fi
 
-REQUIRED_KB=$((DISK_SPACE_REQUIRED * 1024 * 1024))
-AVAIL_KB=$(df -k "$INSTALL_DIR" | awk 'NR==2 {print $4}')
-if [ -z "$AVAIL_KB" ] || [ "$AVAIL_KB" -lt "$REQUIRED_KB" ]; then
-    if [ -n "$AVAIL_KB" ]; then
-        AVAIL_GB=$((AVAIL_KB / 1024 / 1024))
-        printf '%s\n' "${_Y}ERROR:${_R} Need at least ${DISK_SPACE_REQUIRED} GB free in $INSTALL_DIR (about ${AVAIL_GB} GB available)."
-    else
-        printf '%s\n' "${_Y}ERROR:${_R} Could not read free disk space for $INSTALL_DIR."
-    fi
-    exit 1
-fi
-
 if [[ "$NGINX_ENABLED" == "true" ]]; then
     for port in 80 443; do
         if _tcp_port_in_use "$port"; then
@@ -324,6 +334,20 @@ if ! docker info >/dev/null 2>&1; then
     printf '%s\n' "${_Y}ERROR:${_R} Docker daemon is not reachable. Start Docker Desktop (or your engine) and try again."
     exit 1
 fi
+
+REQUIRED_KB=$((DISK_SPACE_REQUIRED * 1024 * 1024))
+DOCKER_ROOT=$(docker info -f '{{.DockerRootDir}}' 2>/dev/null || true)
+AVAIL_KB=$(_docker_engine_avail_kb || true)
+if [ -z "$AVAIL_KB" ] || [ "$AVAIL_KB" -lt "$REQUIRED_KB" ]; then
+    if [ -n "$AVAIL_KB" ]; then
+        AVAIL_GB=$((AVAIL_KB / 1024 / 1024))
+        printf '%s\n' "${_Y}ERROR:${_R} Need at least ${DISK_SPACE_REQUIRED} GB free where Docker stores data (engine root: ${DOCKER_ROOT:-unknown}; about ${AVAIL_GB} GB available)."
+    else
+        printf '%s\n' "${_Y}ERROR:${_R} Could not read free disk space for the Docker engine (DockerRootDir: ${DOCKER_ROOT:-unknown}). Ensure Docker works and outbound image pulls are allowed (uses a short alpine:3.20 run)."
+    fi
+    exit 1
+fi
+ok "Docker engine disk: enough free space for chain data (named volume on ${DOCKER_ROOT:-Docker storage})"
 
 if docker compose version >/dev/null 2>&1; then
     DC="docker compose"

--- a/install_coti-full-node-mac.sh
+++ b/install_coti-full-node-mac.sh
@@ -22,7 +22,9 @@ _div() { printf '%s\n' "${_D}─────────────────
 info() { printf '%s\n' "${_C}→${_R} $*"; }
 ok() { printf '%s\n' "${_G}✓${_R} $*"; }
 
-# Free KiB on the filesystem backing Docker images/volumes (named chain data volumes live here).
+# Free KiB on the filesystem backing Docker images/volumes. Prefer resolving the Docker root
+# through a host bind mount, then fall back to the container root filesystem for Docker Desktop
+# setups where DockerRootDir is reported logically but is not exposed on the host path.
 _docker_engine_avail_kb() {
     local root kb
     docker info >/dev/null 2>&1 || return 1
@@ -40,6 +42,11 @@ _docker_engine_avail_kb() {
             printf '%s\n' "$kb"
             return 0
         fi
+    fi
+    kb=$(docker run --rm alpine:3.20 sh -c "df -Pk / 2>/dev/null | awk 'NR==2{print \$4}'" 2>/dev/null || true)
+    if [ -n "$kb" ] && [ "$kb" -ge 1 ] 2>/dev/null; then
+        printf '%s\n' "$kb"
+        return 0
     fi
     return 1
 }

--- a/install_coti-full-node-mac.sh
+++ b/install_coti-full-node-mac.sh
@@ -458,11 +458,28 @@ serverPort = $FRPS_SERVER_PORT
 $FRPC_AUTH_BLOCK
 
 [[proxies]]
-name = "$FRPC_CUSTOM_DOMAIN"
+name = "$FRPC_CUSTOM_DOMAIN-rpc"
 type = "http"
 localIP = "coti-${NETWORK}-full-node"
 localPort = 8545
 customDomains = ["$FRPC_CUSTOM_DOMAIN"]
+locations = ["/rpc"]
+
+[[proxies]]
+name = "$FRPC_CUSTOM_DOMAIN-ws"
+type = "http"
+localIP = "coti-${NETWORK}-full-node"
+localPort = 8546
+customDomains = ["$FRPC_CUSTOM_DOMAIN"]
+locations = ["/ws"]
+
+[[proxies]]
+name = "$FRPC_CUSTOM_DOMAIN-operator"
+type = "http"
+localIP = "coti-${NETWORK}-operator-dashboard"
+localPort = 8090
+customDomains = ["$FRPC_CUSTOM_DOMAIN"]
+locations = ["/operator"]
 EOF
     done
     unset _frpc_toml_pair _frpc_toml_file _frpc_server_addr
@@ -518,6 +535,10 @@ upstream fullnode_6000 {
     server coti-$NETWORK-full-node:6000  max_fails=3 fail_timeout=30s;
 }
 
+upstream operator_dashboard_8090 {
+    server coti-$NETWORK-operator-dashboard:8090  max_fails=3 fail_timeout=30s;
+}
+
 server {
     listen 443 ssl;
     server_name $FQDN;
@@ -547,6 +568,18 @@ server {
         proxy_set_header Host \$host;
         proxy_pass http://fullnode_6000/debug/metrics/prometheus;
     }
+
+    location = /operator {
+        return 301 https://\$host/operator/;
+    }
+
+    location /operator/ {
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_pass http://operator_dashboard_8090/;
+    }
 }
 
 server {
@@ -572,16 +605,16 @@ _w ""
 if [[ "$NGINX_ENABLED" != "true" ]]; then
     _w "  • Mode: ${_B}no Nginx/SSL on this host${_R}"
     if [[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]] && [[ "$FRPC_ENABLED" == "true" ]]; then
-        _w "  • COTI tunnel: public HTTPS/RPC at ${_B}https://${FRPC_CUSTOM_DOMAIN:-$FQDN}${_R} (edge TLS + DNS by COTI; FRPC to this node)"
+        _w "  • COTI tunnel: JSON-RPC ${_B}https://${FRPC_CUSTOM_DOMAIN:-$FQDN}/rpc${_R}, WebSocket ${_U}https://${FRPC_CUSTOM_DOMAIN:-$FQDN}/ws${_R}, operator ${_U}https://${FRPC_CUSTOM_DOMAIN:-$FQDN}/operator/${_R}"
     else
         _w "  • RPC / WS: published on host ports 8545 / 8546 (see docker-compose)"
     fi
 else
-    _w "  • HTTPS: ${_B}https://$FQDN${_R}"
+    _w "  • HTTPS: ${_B}https://$FQDN${_R} (RPC/WS: /rpc /ws; operator dashboard: /operator/)"
 fi
 if [[ "$FRPC_ENABLED" == "true" ]]; then
     _w "  • FRPC: ${_B}enabled${_R} — gateways $FRPS_SERVER_ADDR_1:$FRPS_SERVER_PORT, $FRPS_SERVER_ADDR_2:$FRPS_SERVER_PORT"
-    _w "  • FRPC custom domain (proxy name): ${FRPC_CUSTOM_DOMAIN}"
+    _w "  • FRPC: host ${_B}${FRPC_CUSTOM_DOMAIN}${_R} — ${_U}/rpc${_R} → 8545, ${_U}/ws${_R} → 8546, ${_U}/operator/${_R} → dashboard (frpc: …-rpc, …-ws, …-operator)"
     if [[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]]; then
         _w "  • Inbound firewall: ${_B}not required${_R} for 80/443/7400 from the internet (outbound FRP + local P2P)"
     fi
@@ -589,5 +622,11 @@ else
     _w "  • FRPC: ${_D}disabled${_R} (wizard tunnel: ${_U}--with-frp${_R}; relay only: ${_U}--frpc-enabled=true${_R})"
 fi
 _w "  • Logs: ${_U}docker logs -f coti-$NETWORK-full-node${_R}"
-_w "  • ${_B}Health check page${_R} (this machine): ${_U}http://127.0.0.1:8090${_R}"
+if [[ "$NGINX_ENABLED" == "true" ]]; then
+    _w "  • ${_B}Health check page${_R}: ${_U}https://$FQDN/operator/${_R} (or local ${_U}http://127.0.0.1:8090${_R})"
+elif [[ "$FRPC_ENABLED" == "true" ]] && [[ -n "${FRPC_CUSTOM_DOMAIN:-}" ]]; then
+    _w "  • ${_B}Health check page${_R}: ${_U}https://$FRPC_CUSTOM_DOMAIN/operator/${_R} (or local ${_U}http://127.0.0.1:8090${_R})"
+else
+    _w "  • ${_B}Health check page${_R} (this machine): ${_U}http://127.0.0.1:8090${_R}"
+fi
 _div

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -52,6 +52,17 @@ print_requirements() {
 info() { printf '%s\n' "${_C}→${_R} $*"; }
 ok() { printf '%s\n' "${_G}✓${_R} $*"; }
 
+# Shown in help text (override if you mirror the installer elsewhere)
+FULLNODE_INSTALLER_URL="${FULLNODE_INSTALLER_URL:-https://fullnode.testnet.coti.io}"
+
+print_install_curl_examples() {
+    _w "Linux, macOS, or Windows WSL (Ubuntu 24.04):"
+    _w "  curl -sL ${FULLNODE_INSTALLER_URL} | sudo bash -s -- \"0x...\" \"your.domain\""
+    _w ""
+    _w "On WSL, run from a directory under your Linux home (e.g. ~/coti), not under /mnt/c/, so Docker can create Unix sockets for the node."
+    _w "Native Windows is not supported for this installer; use WSL (Ubuntu 24.04) or a Linux host."
+}
+
 print_welcome
 read -r -p "Press Enter to continue, or Ctrl+C to abort " < /dev/tty || true
 _w ""
@@ -98,8 +109,7 @@ fi
 if [ "$(id -u)" -ne 0 ]; then
     printf '%s\n' "${_Y}This script must be run as root.${_R}"
     _w ""
-    _w "Example:"
-    _w '  curl -sL https://fullnode.testnet.coti.io | sudo bash -s -- "0x..." "your.domain"'
+    print_install_curl_examples
     exit 1
 fi
 
@@ -193,11 +203,9 @@ fi
 if [ -z "$FQDN" ] || [ -z "$PK" ]; then
     printf '%s\n' "${_Y}ERROR:${_R} Private key and FQDN are required."
     _w ""
-    _w "Example (node only — default):"
-    _w '  curl -sL https://fullnode.testnet.coti.io | sudo bash -s -- "0x..." "your.domain"'
+    print_install_curl_examples
     _w ""
-    _w "With Nginx + Let's Encrypt:"
-    _w '  ... | sudo bash -s -- "0x..." "your.domain" --nginx'
+    _w "With Nginx + Let's Encrypt, append after the FQDN: --nginx"
     exit 1
 fi
 

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -101,7 +101,7 @@ if [ -f "$INSTALLER_ENV_FILE" ]; then
 fi
 
 # Default values (can be overridden in installer.env)
-: "${DISK_SPACE_REQUIRED:=40}"      # GB
+: "${DISK_SPACE_REQUIRED:=90}"      # GB
 
 print_requirements
 read -r -p "Press Enter to continue, or Ctrl+C to abort " < /dev/tty || true

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e # Exit immediately if a command exits with a non-zero status
 
-set -v
-set -x
-
 # present the steps of the installer
 echo "====================================================="
 echo "       COTI Full Node Automated Installer"

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -626,4 +626,5 @@ else
     _w "  • FRPC: ${_D}disabled${_R} (wizard tunnel: ${_U}--with-frp${_R}; relay only: ${_U}--frpc-enabled=true${_R})"
 fi
 _w "  • Logs: ${_U}docker logs -f coti-$NETWORK-full-node${_R}"
+_w "  • ${_B}Health check page${_R} (this machine): ${_U}http://127.0.0.1:8090${_R} — simple green/red status for support"
 _div

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -29,7 +29,7 @@ print_welcome() {
     _w "  3. Install host dependencies (Docker, tools)"
     _w "  4. Clone repository and prepare directory"
     _w "  5. Generate .env and node identity"
-    _w "  6. Optional: Nginx + Let's Encrypt (${_Y}off by default${_R}; use ${_U}--nginx${_R} or ${_U}NGINX_ENABLED=true${_R})"
+    _w "  6. Optional: Nginx + Let's Encrypt (${_Y}off by default${_R}; use ${_U}--with-nginx${_R} or ${_U}NGINX_ENABLED=true${_R})"
     _w "  7. Optional: FRPC (${_Y}off by default${_R}; ${_U}--with-frp${_R} = wizard tunnel: FRPC on, no Nginx; ${_U}--frpc${_R} = FRPC only)"
     _w "  8. Start the stack"
     _w ""
@@ -121,10 +121,10 @@ COTI_TUNNEL_INSTALL=false
 POSITIONAL=()
 for arg in "$@"; do
     case "$arg" in
-        --no-nginx)
+        --without-nginx)
             NGINX_ENABLED=false
             ;;
-        --nginx)
+        --with-nginx)
             NGINX_ENABLED=true
             COTI_TUNNEL_INSTALL=false
             ;;
@@ -142,7 +142,7 @@ for arg in "$@"; do
             NGINX_ENABLED=false
             COTI_TUNNEL_INSTALL=true
             ;;
-        --no-frpc)
+        --without-frp)
             FRPC_ENABLED=false
             COTI_TUNNEL_INSTALL=false
             ;;
@@ -222,7 +222,7 @@ if [ -z "$FQDN" ] || [ -z "$PK" ]; then
     _w ""
     print_install_curl_examples
     _w ""
-    _w "With Nginx + Let's Encrypt, append after the FQDN: --nginx"
+    _w "With Nginx + Let's Encrypt, append after the FQDN: --with-nginx"
     _w "Wizard tunnel (COTI subdomain + FRPC, no host TLS): --with-frp"
     exit 1
 fi

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -30,7 +30,7 @@ print_welcome() {
     _w "  4. Clone repository and prepare directory"
     _w "  5. Generate .env and node identity"
     _w "  6. Optional: Nginx + Let's Encrypt (${_Y}off by default${_R}; use ${_U}--with-nginx${_R} or ${_U}NGINX_ENABLED=true${_R})"
-    _w "  7. Optional: FRPC (${_Y}off by default${_R}; ${_U}--with-frp${_R} = wizard tunnel: FRPC on, no Nginx; ${_U}--frpc${_R} = FRPC only)"
+    _w "  7. Optional: FRPC (${_Y}off by default${_R}; ${_U}--with-frp${_R} = COTI wizard tunnel: FRPC on, no Nginx; ${_U}--frpc-enabled=true${_R} = FRPC relay only, no wizard)"
     _w "  8. Start the stack"
     _w ""
     _div
@@ -94,7 +94,10 @@ if declare -p FRPS_SERVER_ADDR_2 >/dev/null 2>&1; then
 fi
 
 : "${DOCKER_FULL_NODE_IMAGE_VERSION:=1.2.0}"
+# IMAGE (optional, in installer.env) overrides DOCKER_FULL_NODE_IMAGE_VERSION for upgrades.
+DOCKER_FULL_NODE_IMAGE_VERSION="${IMAGE:-$DOCKER_FULL_NODE_IMAGE_VERSION}"
 : "${CLONE_BRANCH:=coti-testnet}"
+# Default network label for this installer package (mainnet builds set NETWORK=mainnet here).
 : "${NETWORK:=testnet}"
 : "${NGINX_ENABLED:=false}"
 : "${FRPC_ENABLED:=false}"
@@ -182,7 +185,7 @@ PK="${POSITIONAL[0]:-}"
 FQDN="${POSITIONAL[1]:-}"
 
 if [[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]] && [[ "$FRPC_ENABLED" != "true" ]]; then
-    printf '%s\n' "${_Y}ERROR:${_R} COTI tunnel install requires FRPC (--with-frp implies --frpc)."
+    printf '%s\n' "${_Y}ERROR:${_R} COTI tunnel install requires FRPC enabled (use ${_U}--with-frp${_R})."
     exit 1
 fi
 
@@ -305,7 +308,7 @@ if [[ "$NGINX_ENABLED" == "true" ]]; then
 fi
 
 # --- 1e. CHECK PORT 7400 IS AVAILABLE ---
-if ss -tlnp 2>/dev/null | grep -qE "7400\s"; then
+if ss -tlnp 2>/dev/null | grep -qE ':7400(\s|$)'; then
     printf '%s\n' "${_Y}ERROR:${_R} Port 7400 is already in use."
     exit 1
 fi
@@ -403,9 +406,31 @@ info "Cloning coti-full-node (${CLONE_BRANCH})..."
 git clone -b "$CLONE_BRANCH" https://github.com/coti-io/coti-full-node.git
 cd coti-full-node
 
+# Persist installation-level settings into the clone (image tag, network, etc.).
+# Per-host values go in .env; operators upgrade the container image by editing DOCKER_FULL_NODE_IMAGE_VERSION or IMAGE here.
+info "Writing installer.env (installation metadata)..."
+cat <<EOF > installer.env
+# Installation / packaging defaults for this checkout (not host-specific).
+# Per-host settings are in .env (sourced after this file by start/stop scripts).
+#
+# Bump DOCKER_FULL_NODE_IMAGE_VERSION (or set IMAGE=) to upgrade the node image, then run ./start_coti-full-node.sh
+
+DISK_SPACE_REQUIRED=${DISK_SPACE_REQUIRED}
+DOCKER_FULL_NODE_IMAGE_VERSION=${DOCKER_FULL_NODE_IMAGE_VERSION}
+CLONE_BRANCH=${CLONE_BRANCH}
+NETWORK=${NETWORK}
+EOF
+
 # --- 4. GENERATE .ENV FILE ---
 info "Writing .env..."
-EXT_IP=$(curl -s https://api.ipify.org)
+if ! EXT_IP=$(curl -fsS --connect-timeout 10 --max-time 20 https://api.ipify.org); then
+    printf '%s\n' "${_Y}ERROR:${_R} Could not detect public IP (api.ipify.org). Check outbound HTTPS and re-run."
+    exit 1
+fi
+if [ -z "$EXT_IP" ]; then
+    printf '%s\n' "${_Y}ERROR:${_R} Public IP lookup returned an empty response."
+    exit 1
+fi
 
 cat <<EOF > .env
 FULLNODE_EXT_IP=$EXT_IP
@@ -427,21 +452,22 @@ info "Writing node key..."
 echo -n "$PK_CLEAN" > ./nodekey
 
 # --- 5b. CONFIGURE FRPC (RPC RELAY ONLY) ---
-FRPC_AUTH_BLOCK=""
-if [ -n "$FRPC_AUTH_TOKEN" ]; then
-    FRPC_AUTH_BLOCK=$(cat <<EOF
+if [[ "$FRPC_ENABLED" == "true" ]]; then
+    FRPC_AUTH_BLOCK=""
+    if [ -n "$FRPC_AUTH_TOKEN" ]; then
+        FRPC_AUTH_BLOCK=$(cat <<EOF
 auth.method = "token"
 auth.token = "$FRPC_AUTH_TOKEN"
 EOF
 )
-fi
+    fi
 
-for _frpc_toml_pair in \
-    "frpc-1.toml:$FRPS_SERVER_ADDR_1" \
-    "frpc-2.toml:$FRPS_SERVER_ADDR_2"; do
-    _frpc_toml_file="${_frpc_toml_pair%%:*}"
-    _frpc_server_addr="${_frpc_toml_pair#*:}"
-    cat <<EOF > "./$_frpc_toml_file"
+    for _frpc_toml_pair in \
+        "frpc-1.toml:$FRPS_SERVER_ADDR_1" \
+        "frpc-2.toml:$FRPS_SERVER_ADDR_2"; do
+        _frpc_toml_file="${_frpc_toml_pair%%:*}"
+        _frpc_server_addr="${_frpc_toml_pair#*:}"
+        cat <<EOF > "./$_frpc_toml_file"
 serverAddr = "$_frpc_server_addr"
 serverPort = $FRPS_SERVER_PORT
 $FRPC_AUTH_BLOCK
@@ -449,12 +475,13 @@ $FRPC_AUTH_BLOCK
 [[proxies]]
 name = "$FRPC_CUSTOM_DOMAIN"
 type = "http"
-localIP = "coti-testnet-full-node"
-localPort = $COTI_FULL_NODE_RPC_LOCAL_PORT
+localIP = "coti-${NETWORK}-full-node"
+localPort = 8545
 customDomains = ["$FRPC_CUSTOM_DOMAIN"]
 EOF
-done
-unset _frpc_toml_pair _frpc_toml_file _frpc_server_addr
+    done
+    unset _frpc_toml_pair _frpc_toml_file _frpc_server_addr
+fi
 
 # --- 6-8. SSL AND NGINX SETUP (skipped when NGINX_ENABLED=false) ---
 if [[ "$NGINX_ENABLED" == "true" ]]; then
@@ -552,7 +579,7 @@ if [[ "$NGINX_ENABLED" != "true" ]]; then
     if [[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]] && [[ "$FRPC_ENABLED" == "true" ]]; then
         _w "  • COTI tunnel: public HTTPS/RPC at ${_B}https://${FRPC_CUSTOM_DOMAIN:-$FQDN}${_R} (edge TLS + DNS by COTI; FRPC to this node)"
     else
-        _w "  • RPC / WS: published on host ports 8545 / 8546 (see docker-compose)"
+        _w "  • RPC / WS: published on host ports ${COTI_FULL_NODE_RPC_LOCAL_PORT} / 8546 (see docker-compose)"
     fi
 else
     _w "  • HTTPS: ${_B}https://$FQDN${_R}"
@@ -564,7 +591,7 @@ if [[ "$FRPC_ENABLED" == "true" ]]; then
         _w "  • Inbound firewall: ${_B}not required${_R} for 80/443/7400 from the internet (outbound FRP + local P2P)"
     fi
 else
-    _w "  • FRPC: ${_D}disabled${_R} (wizard tunnel: ${_U}--with-frp${_R}; or ${_U}--frpc${_R})"
+    _w "  • FRPC: ${_D}disabled${_R} (wizard tunnel: ${_U}--with-frp${_R}; relay only: ${_U}--frpc-enabled=true${_R})"
 fi
 _w "  • Logs: ${_U}docker logs -f coti-$NETWORK-full-node${_R}"
 _div

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -48,7 +48,6 @@ read -p "Press Enter to continue or Ctrl+C to abort" < /dev/tty
 : "${FRPC_ENABLED:=false}"
 : "${FRPS_SERVER_ADDR:=gateway.fullnode.testnet.coti.io}"
 : "${FRPS_SERVER_PORT:=7000}"
-: "${FRPC_PROXY_NAME:=}"
 : "${FRPC_CUSTOM_DOMAIN:=}"
 : "${FRPC_AUTH_TOKEN:=}"
 : "${COTI_FULL_NODE_RPC_LOCAL_PORT:=8545}"
@@ -153,10 +152,6 @@ fi
 
 if [[ "$FRPC_ENABLED" == "true" ]] && [ -z "$FRPC_CUSTOM_DOMAIN" ]; then
     FRPC_CUSTOM_DOMAIN="$FQDN"
-fi
-
-if [ -z "$FRPC_PROXY_NAME" ]; then
-    FRPC_PROXY_NAME="rpc-$FQDN"
 fi
 
 if [[ ! "$FRPS_SERVER_PORT" =~ ^[0-9]+$ ]] || [ "$FRPS_SERVER_PORT" -lt 1 ] || [ "$FRPS_SERVER_PORT" -gt 65535 ]; then
@@ -309,7 +304,6 @@ NGINX_ENABLED=$NGINX_ENABLED
 FRPC_ENABLED=$FRPC_ENABLED
 FRPS_SERVER_ADDR=$FRPS_SERVER_ADDR
 FRPS_SERVER_PORT=$FRPS_SERVER_PORT
-FRPC_PROXY_NAME=$FRPC_PROXY_NAME
 FRPC_CUSTOM_DOMAIN=$FRPC_CUSTOM_DOMAIN
 FRPC_AUTH_TOKEN=$FRPC_AUTH_TOKEN
 COTI_FULL_NODE_RPC_LOCAL_PORT=$COTI_FULL_NODE_RPC_LOCAL_PORT
@@ -336,7 +330,7 @@ serverPort = $FRPS_SERVER_PORT
 $FRPC_AUTH_BLOCK
 
 [[proxies]]
-name = "$FRPC_PROXY_NAME"
+name = "$FRPC_CUSTOM_DOMAIN"
 type = "http"
 localIP = "coti-testnet-full-node"
 localPort = $COTI_FULL_NODE_RPC_LOCAL_PORT

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -54,8 +54,9 @@ info() { printf '%s\n' "${_C}→${_R} $*"; }
 ok() { printf '%s\n' "${_G}✓${_R} $*"; }
 
 # Free KiB on the filesystem backing Docker images/volumes. Named chain data volumes live here,
-# not on the project directory. A short-lived container + bind mount reports the engine disk
-# correctly for Docker Desktop and WSL, not only native Linux.
+# not on the project directory. Prefer resolving the Docker root through a host bind mount, then
+# fall back to the container root filesystem for Docker Desktop / WSL setups where DockerRootDir
+# is reported logically but is not visible in the distro filesystem.
 _docker_engine_avail_kb() {
     local root kb
     docker info >/dev/null 2>&1 || return 1
@@ -73,6 +74,11 @@ _docker_engine_avail_kb() {
             printf '%s\n' "$kb"
             return 0
         fi
+    fi
+    kb=$(docker run --rm alpine:3.20 sh -c "df -Pk / 2>/dev/null | awk 'NR==2{print \$4}'" 2>/dev/null || true)
+    if [ -n "$kb" ] && [ "$kb" -ge 1 ] 2>/dev/null; then
+        printf '%s\n' "$kb"
+        return 0
     fi
     return 1
 }

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -26,7 +26,7 @@ if [ -f "$INSTALLER_ENV_FILE" ]; then
 fi
 
 # Default values (can be overridden in installer.env)
-: "${DISK_SPACE_REQUIRED:=45}"      # GB
+: "${DISK_SPACE_REQUIRED:=40}"      # GB
 
 # present the requirements for the installer
 echo "====================================================="

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -30,7 +30,7 @@ print_welcome() {
     _w "  4. Clone repository and prepare directory"
     _w "  5. Generate .env and node identity"
     _w "  6. Optional: Nginx + Let's Encrypt (${_Y}off by default${_R}; use ${_U}--nginx${_R} or ${_U}NGINX_ENABLED=true${_R})"
-    _w "  7. Optional: FRPC RPC relay (${_Y}off by default${_R}; use ${_U}--frpc${_R})"
+    _w "  7. Optional: FRPC (${_Y}off by default${_R}; ${_U}--with-frp${_R} = wizard tunnel: FRPC on, no Nginx; ${_U}--frpc${_R} = FRPC only)"
     _w "  8. Start the stack"
     _w ""
     _div
@@ -42,9 +42,10 @@ print_requirements() {
     _div
     _w "  • OS: Ubuntu 24.04 LTS (supported by COTI)"
     _w "  • Free disk: ${DISK_SPACE_REQUIRED} GB in the install directory"
-    _w "  • Port 7400 available (node P2P)"
-    _w "  • With Nginx/SSL: ports 80 and 443 free; firewall allows 80/443/7400"
-    _w "  • Without Nginx: RPC/WS on local ports (see success message)"
+    _w "  • Port 7400 must be free locally for the node container (P2P)"
+    _w "  • ${_B}With Nginx/SSL:${_R} ports 80 and 443 free; firewall allows 80/443/7400"
+    _w "  • ${_B}With --with-frp${_R} (COTI wizard tunnel): no Nginx on host; inbound 80/443/7400 on the ${_U}firewall${_R} not required (FRP + edge TLS)"
+    _w "  • Without Nginx and without FRPC: RPC/WS on local ports (see success message)"
     _w ""
     _div
 }
@@ -116,6 +117,7 @@ fi
 # Split flags from positional arguments (flags may appear before or after PK/FQDN)
 FRPS_SERVER_ADDR_1_EXPLICIT=false
 FRPS_SERVER_ADDR_2_EXPLICIT=false
+COTI_TUNNEL_INSTALL=false
 POSITIONAL=()
 for arg in "$@"; do
     case "$arg" in
@@ -124,21 +126,31 @@ for arg in "$@"; do
             ;;
         --nginx)
             NGINX_ENABLED=true
+            COTI_TUNNEL_INSTALL=false
             ;;
         --nginx-enabled=*)
             NGINX_ENABLED="${arg#*=}"
+            if [[ "$NGINX_ENABLED" == "true" ]]; then
+                COTI_TUNNEL_INSTALL=false
+            fi
             ;;
         --staging)
             CERTBOT_STAGING=true
             ;;
-        --frpc)
+        --with-frp)
             FRPC_ENABLED=true
+            NGINX_ENABLED=false
+            COTI_TUNNEL_INSTALL=true
             ;;
         --no-frpc)
             FRPC_ENABLED=false
+            COTI_TUNNEL_INSTALL=false
             ;;
         --frpc-enabled=*)
             FRPC_ENABLED="${arg#*=}"
+            if [[ "$FRPC_ENABLED" != "true" ]]; then
+                COTI_TUNNEL_INSTALL=false
+            fi
             ;;
         --frpc-custom-domain=*)
             FRPC_CUSTOM_DOMAIN="${arg#*=}"
@@ -168,6 +180,11 @@ done
 
 PK="${POSITIONAL[0]:-}"
 FQDN="${POSITIONAL[1]:-}"
+
+if [[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]] && [[ "$FRPC_ENABLED" != "true" ]]; then
+    printf '%s\n' "${_Y}ERROR:${_R} COTI tunnel install requires FRPC (--with-frp implies --frpc)."
+    exit 1
+fi
 
 # Legacy single gateway: apply FRPS_SERVER_ADDR where a region host was not set (installer.env) or overridden (CLI).
 if [ -n "${FRPS_SERVER_ADDR:-}" ]; then
@@ -206,6 +223,7 @@ if [ -z "$FQDN" ] || [ -z "$PK" ]; then
     print_install_curl_examples
     _w ""
     _w "With Nginx + Let's Encrypt, append after the FQDN: --nginx"
+    _w "Wizard tunnel (COTI subdomain + FRPC, no host TLS): --with-frp"
     exit 1
 fi
 
@@ -252,7 +270,7 @@ if [[ ! "$COTI_FULL_NODE_RPC_LOCAL_PORT" =~ ^[0-9]+$ ]] || [ "$COTI_FULL_NODE_RP
     exit 1
 fi
 
-info "Install mode: Nginx/SSL ${_B}${NGINX_ENABLED}${_R} · FRPC relay ${_B}${FRPC_ENABLED}${_R}"
+info "Install mode: Nginx/SSL ${_B}${NGINX_ENABLED}${_R} · FRPC relay ${_B}${FRPC_ENABLED}${_R}$([[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]] && printf ' · %s' "${_B}COTI tunnel (wizard)${_R}")"
 _w ""
 
 # --- 1b. CHECK INSTALL DIRECTORY (writability + disk space) ---
@@ -293,6 +311,8 @@ if ss -tlnp 2>/dev/null | grep -qE "7400\s"; then
 fi
 
 # --- 1d/1f. CHECK FIREWALL/ IPTABLES RULES FOR REQUIRED PORTS ---
+# COTI tunnel (--with-frp): public RPC/HTTPS and much of P2P reachability go via FRP; skip inbound FW checks.
+if [[ "${COTI_TUNNEL_INSTALL:-false}" != "true" ]]; then
 # Only perform ufw checks if ufw is installed and active.
 if command -v ufw >/dev/null 2>&1; then
     if ufw status | grep -qi "Status: active"; then
@@ -328,6 +348,7 @@ if command -v iptables >/dev/null 2>&1; then
         printf '%s\n' "${_Y}ERROR:${_R} iptables appears to block port 7400."
         exit 1
     fi
+fi
 fi
 
 # --- 2. INSTALL HOST DEPENDENCIES ---
@@ -527,16 +548,23 @@ _div
 ok "COTI full node is starting."
 _w ""
 if [[ "$NGINX_ENABLED" != "true" ]]; then
-    _w "  • Mode: ${_B}node only${_R} (no Nginx/SSL in Docker)"
-    _w "  • RPC / WS: published on host ports 8545 / 8546 (see docker-compose)"
+    _w "  • Mode: ${_B}no Nginx/SSL on this host${_R}"
+    if [[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]] && [[ "$FRPC_ENABLED" == "true" ]]; then
+        _w "  • COTI tunnel: public HTTPS/RPC at ${_B}https://${FRPC_CUSTOM_DOMAIN:-$FQDN}${_R} (edge TLS + DNS by COTI; FRPC to this node)"
+    else
+        _w "  • RPC / WS: published on host ports 8545 / 8546 (see docker-compose)"
+    fi
 else
     _w "  • HTTPS: ${_B}https://$FQDN${_R}"
 fi
 if [[ "$FRPC_ENABLED" == "true" ]]; then
     _w "  • FRPC: ${_B}enabled${_R} — gateways $FRPS_SERVER_ADDR_1:$FRPS_SERVER_PORT, $FRPS_SERVER_ADDR_2:$FRPS_SERVER_PORT"
-    _w "  • Public RPC host: ${FRPC_CUSTOM_DOMAIN}"
+    _w "  • FRPC custom domain (proxy name): ${FRPC_CUSTOM_DOMAIN}"
+    if [[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]]; then
+        _w "  • Inbound firewall: ${_B}not required${_R} for 80/443/7400 from the internet (outbound FRP + local P2P)"
+    fi
 else
-    _w "  • FRPC: ${_D}disabled${_R} (enable with --frpc)"
+    _w "  • FRPC: ${_D}disabled${_R} (wizard tunnel: ${_U}--with-frp${_R}; or ${_U}--frpc${_R})"
 fi
 _w "  • Logs: ${_U}docker logs -f coti-$NETWORK-full-node${_R}"
 _div

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -41,12 +41,19 @@ echo "6. Iptables must not be blocking port 7400 (if iptables is not used, skip 
 echo "====================================================="
 read -p "Press Enter to continue or Ctrl+C to abort" < /dev/tty
 
+_FRPS_SERVER_ADDR_1_FROM_ENV=false
+_FRPS_SERVER_ADDR_2_FROM_ENV=false
+[[ -v FRPS_SERVER_ADDR_1 ]] && _FRPS_SERVER_ADDR_1_FROM_ENV=true
+[[ -v FRPS_SERVER_ADDR_2 ]] && _FRPS_SERVER_ADDR_2_FROM_ENV=true
+
 : "${DOCKER_FULL_NODE_IMAGE_VERSION:=1.2.0}"
 : "${CLONE_BRANCH:=coti-testnet}"
 : "${NETWORK:=testnet}"
 : "${NGINX_ENABLED:=true}"
 : "${FRPC_ENABLED:=false}"
-: "${FRPS_SERVER_ADDR:=gateway.fullnode.testnet.coti.io}"
+: "${FRPS_SERVER_ADDR:=}"
+: "${FRPS_SERVER_ADDR_1:=virginia.fullnode.testnet.coti.io}"
+: "${FRPS_SERVER_ADDR_2:=frankfurt.fullnode.testnet.coti.io}"
 : "${FRPS_SERVER_PORT:=7000}"
 : "${FRPC_CUSTOM_DOMAIN:=}"
 : "${FRPC_AUTH_TOKEN:=}"
@@ -64,6 +71,9 @@ fi
 # Accept PK and FQDN as positional arguments
 PK="$1"
 FQDN="$2"
+
+FRPS_SERVER_ADDR_1_EXPLICIT=false
+FRPS_SERVER_ADDR_2_EXPLICIT=false
 
 # Optional FRPC overrides via environment variables or flags.
 for arg in "$@"; do
@@ -89,11 +99,29 @@ for arg in "$@"; do
         --frps-server-addr=*)
             FRPS_SERVER_ADDR="${arg#*=}"
             ;;
+        --frps-server-addr-1=*)
+            FRPS_SERVER_ADDR_1="${arg#*=}"
+            FRPS_SERVER_ADDR_1_EXPLICIT=true
+            ;;
+        --frps-server-addr-2=*)
+            FRPS_SERVER_ADDR_2="${arg#*=}"
+            FRPS_SERVER_ADDR_2_EXPLICIT=true
+            ;;
         --frps-server-port=*)
             FRPS_SERVER_PORT="${arg#*=}"
             ;;
     esac
 done
+
+# Legacy single gateway: apply FRPS_SERVER_ADDR where a region host was not set (installer.env) or overridden (CLI).
+if [ -n "${FRPS_SERVER_ADDR:-}" ]; then
+    if [[ "$FRPS_SERVER_ADDR_1_EXPLICIT" != "true" ]] && [[ "$_FRPS_SERVER_ADDR_1_FROM_ENV" != "true" ]]; then
+        FRPS_SERVER_ADDR_1="$FRPS_SERVER_ADDR"
+    fi
+    if [[ "$FRPS_SERVER_ADDR_2_EXPLICIT" != "true" ]] && [[ "$_FRPS_SERVER_ADDR_2_FROM_ENV" != "true" ]]; then
+        FRPS_SERVER_ADDR_2="$FRPS_SERVER_ADDR"
+    fi
+fi
 
 echo "====================================================="
 echo "       COTI Full Node Automated Installer"
@@ -303,6 +331,8 @@ FULLNODE_FQDN=$FQDN
 NGINX_ENABLED=$NGINX_ENABLED
 FRPC_ENABLED=$FRPC_ENABLED
 FRPS_SERVER_ADDR=$FRPS_SERVER_ADDR
+FRPS_SERVER_ADDR_1=$FRPS_SERVER_ADDR_1
+FRPS_SERVER_ADDR_2=$FRPS_SERVER_ADDR_2
 FRPS_SERVER_PORT=$FRPS_SERVER_PORT
 FRPC_CUSTOM_DOMAIN=$FRPC_CUSTOM_DOMAIN
 FRPC_AUTH_TOKEN=$FRPC_AUTH_TOKEN
@@ -324,8 +354,13 @@ EOF
 )
 fi
 
-cat <<EOF > ./frpc.toml
-serverAddr = "$FRPS_SERVER_ADDR"
+for _frpc_toml_pair in \
+    "frpc-1.toml:$FRPS_SERVER_ADDR_1" \
+    "frpc-2.toml:$FRPS_SERVER_ADDR_2"; do
+    _frpc_toml_file="${_frpc_toml_pair%%:*}"
+    _frpc_server_addr="${_frpc_toml_pair#*:}"
+    cat <<EOF > "./$_frpc_toml_file"
+serverAddr = "$_frpc_server_addr"
 serverPort = $FRPS_SERVER_PORT
 $FRPC_AUTH_BLOCK
 
@@ -336,6 +371,8 @@ localIP = "coti-testnet-full-node"
 localPort = $COTI_FULL_NODE_RPC_LOCAL_PORT
 customDomains = ["$FRPC_CUSTOM_DOMAIN"]
 EOF
+done
+unset _frpc_toml_pair _frpc_toml_file _frpc_server_addr
 
 # --- 6-8. SSL AND NGINX SETUP (skipped when NGINX_ENABLED=false) ---
 if [[ "$NGINX_ENABLED" == "true" ]]; then
@@ -434,7 +471,7 @@ else
 fi
 if [[ "$FRPC_ENABLED" == "true" ]]; then
     echo " FRPC RPC relay: enabled"
-    echo " FRPS gateway: $FRPS_SERVER_ADDR:$FRPS_SERVER_PORT"
+    echo " FRPS gateways: $FRPS_SERVER_ADDR_1:$FRPS_SERVER_PORT, $FRPS_SERVER_ADDR_2:$FRPS_SERVER_PORT"
     echo " Public RPC domain: ${FRPC_CUSTOM_DOMAIN}"
 else
     echo " FRPC RPC relay: disabled"

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -41,7 +41,7 @@ print_requirements() {
     _banner_line "  Requirements"
     _div
     _w "  • OS: Ubuntu 24.04 LTS (supported by COTI)"
-    _w "  • Free disk: ${DISK_SPACE_REQUIRED} GB in the install directory"
+    _w "  • Free disk: ${DISK_SPACE_REQUIRED} GB where Docker stores images/volumes (chain data uses a named volume, not the project folder)"
     _w "  • Port 7400 must be free locally for the node container (P2P)"
     _w "  • ${_B}With Nginx/SSL:${_R} ports 80 and 443 free; firewall allows 80/443/7400"
     _w "  • ${_B}With --with-frp${_R} (COTI wizard tunnel): no Nginx on host; inbound 80/443/7400 on the ${_U}firewall${_R} not required (FRP + edge TLS)"
@@ -52,6 +52,30 @@ print_requirements() {
 
 info() { printf '%s\n' "${_C}→${_R} $*"; }
 ok() { printf '%s\n' "${_G}✓${_R} $*"; }
+
+# Free KiB on the filesystem backing Docker images/volumes. Named chain data volumes live here,
+# not on the project directory. A short-lived container + bind mount reports the engine disk
+# correctly for Docker Desktop and WSL, not only native Linux.
+_docker_engine_avail_kb() {
+    local root kb
+    docker info >/dev/null 2>&1 || return 1
+    root=$(docker info -f '{{.DockerRootDir}}' 2>/dev/null) || return 1
+    [ -n "$root" ] || return 1
+    root="${root%/}"
+    kb=$(docker run --rm -v /:/host:ro alpine:3.20 sh -c "df -Pk '/host${root}' 2>/dev/null | awk 'NR==2{print \$4}'" 2>/dev/null || true)
+    if [ -n "$kb" ] && [ "$kb" -ge 1 ] 2>/dev/null; then
+        printf '%s\n' "$kb"
+        return 0
+    fi
+    if [ -e "$root" ]; then
+        kb=$(df -Pk "$root" 2>/dev/null | awk 'NR==2{print $4}')
+        if [ -n "$kb" ] && [ "$kb" -ge 1 ] 2>/dev/null; then
+            printf '%s\n' "$kb"
+            return 0
+        fi
+    fi
+    return 1
+}
 
 # Shown in help text (override if you mirror the installer elsewhere)
 FULLNODE_INSTALLER_URL="${FULLNODE_INSTALLER_URL:-https://fullnode.testnet.coti.io}"
@@ -276,23 +300,11 @@ fi
 info "Install mode: Nginx/SSL ${_B}${NGINX_ENABLED}${_R} · FRPC relay ${_B}${FRPC_ENABLED}${_R}$([[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]] && printf ' · %s' "${_B}COTI tunnel (wizard)${_R}")"
 _w ""
 
-# --- 1b. CHECK INSTALL DIRECTORY (writability + disk space) ---
+# --- 1b. CHECK INSTALL DIRECTORY (writability; disk space for chain data is checked after Docker is up) ---
 INSTALL_DIR="$(pwd)"
 if [ ! -w "$INSTALL_DIR" ]; then
     printf '%s\n' "${_Y}ERROR:${_R} Cannot write to current directory ($INSTALL_DIR)."
     _w "Run the installer from a writable directory (for example cd ~)."
-    exit 1
-fi
-
-REQUIRED_KB=$((DISK_SPACE_REQUIRED * 1024 * 1024))
-AVAIL_KB=$(df -P "$INSTALL_DIR" | awk 'NR==2 {print $4}')
-if [ -z "$AVAIL_KB" ] || [ "$AVAIL_KB" -lt "$REQUIRED_KB" ]; then
-    if [ -n "$AVAIL_KB" ]; then
-        AVAIL_GB=$((AVAIL_KB / 1024 / 1024))
-        printf '%s\n' "${_Y}ERROR:${_R} Need at least ${DISK_SPACE_REQUIRED} GB free in $INSTALL_DIR (about ${AVAIL_GB} GB available)."
-    else
-        printf '%s\n' "${_Y}ERROR:${_R} Could not read free disk space for $INSTALL_DIR."
-    fi
     exit 1
 fi
 
@@ -391,6 +403,33 @@ if docker compose version >/dev/null 2>&1; then
 else
     DC="docker-compose"
 fi
+
+# --- 2b. CHECK DOCKER ENGINE DISK (named volumes for chain data live on the engine filesystem) ---
+if ! docker info >/dev/null 2>&1; then
+    info "Waiting for Docker daemon..."
+    for _i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+        sleep 1
+        docker info >/dev/null 2>&1 && break
+    done
+fi
+if ! docker info >/dev/null 2>&1; then
+    printf '%s\n' "${_Y}ERROR:${_R} Docker daemon is not reachable. Try: systemctl start docker"
+    exit 1
+fi
+
+REQUIRED_KB=$((DISK_SPACE_REQUIRED * 1024 * 1024))
+DOCKER_ROOT=$(docker info -f '{{.DockerRootDir}}' 2>/dev/null || true)
+AVAIL_KB=$(_docker_engine_avail_kb || true)
+if [ -z "$AVAIL_KB" ] || [ "$AVAIL_KB" -lt "$REQUIRED_KB" ]; then
+    if [ -n "$AVAIL_KB" ]; then
+        AVAIL_GB=$((AVAIL_KB / 1024 / 1024))
+        printf '%s\n' "${_Y}ERROR:${_R} Need at least ${DISK_SPACE_REQUIRED} GB free where Docker stores data (engine root: ${DOCKER_ROOT:-unknown}; about ${AVAIL_GB} GB available)."
+    else
+        printf '%s\n' "${_Y}ERROR:${_R} Could not read free disk space for the Docker engine (DockerRootDir: ${DOCKER_ROOT:-unknown}). Ensure Docker works and outbound image pulls are allowed (uses a short alpine:3.20 run)."
+    fi
+    exit 1
+fi
+ok "Docker engine disk: enough free space for chain data (named volume on ${DOCKER_ROOT:-Docker storage})"
 
 # --- 3. CLONE/PREPARE DIRECTORY ---
 # Require a clean directory: no existing clone (avoids old-version conflicts).

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -26,7 +26,7 @@ if [ -f "$INSTALLER_ENV_FILE" ]; then
 fi
 
 # Default values (can be overridden in installer.env)
-: "${DISK_SPACE_REQUIRED:=90}"      # GB
+: "${DISK_SPACE_REQUIRED:=45}"      # GB
 
 # present the requirements for the installer
 echo "====================================================="

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e # Exit immediately if a command exits with a non-zero status
 
+set -v
+
 # present the steps of the installer
 echo "====================================================="
 echo "       COTI Full Node Automated Installer"

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -2,6 +2,7 @@
 set -e # Exit immediately if a command exits with a non-zero status
 
 set -v
+set -x
 
 # present the steps of the installer
 echo "====================================================="

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -11,7 +11,7 @@ echo "3. Install host dependencies"
 echo "4. Clone/prepare directory"
 echo "5. Generate .env file"
 echo "6. Configure private key (nodekey)"
-echo "7. SSL and Nginx setup (skipped with --no-nginx, use --staging for Let's Encrypt staging)"
+echo "7. SSL and Nginx setup (skipped when NGINX_ENABLED=false or with --no-nginx; use --staging for Let's Encrypt staging)"
 echo "8. Final launch"
 echo "====================================================="
 # Read from /dev/tty so prompts work when script is piped (curl | bash) - avoids consuming the script from stdin
@@ -44,6 +44,7 @@ read -p "Press Enter to continue or Ctrl+C to abort" < /dev/tty
 : "${DOCKER_FULL_NODE_IMAGE_VERSION:=1.2.0}"
 : "${CLONE_BRANCH:=coti-testnet}"
 : "${NETWORK:=testnet}"
+: "${NGINX_ENABLED:=true}"
 : "${FRPC_ENABLED:=false}"
 : "${FRPS_SERVER_ADDR:=gateway.fullnode.testnet.coti.io}"
 : "${FRPS_SERVER_PORT:=7000}"
@@ -69,7 +70,10 @@ FQDN="$2"
 for arg in "$@"; do
     case "$arg" in
         --no-nginx)
-            NO_NGINX=true
+            NGINX_ENABLED=false
+            ;;
+        --nginx-enabled=*)
+            NGINX_ENABLED="${arg#*=}"
             ;;
         --staging)
             CERTBOT_STAGING=true
@@ -135,6 +139,12 @@ if [[ ! "$FQDN" =~ ^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$ ]] || [ "${#FQDN}" 
     exit 1
 fi
 
+# Validate NGINX_ENABLED.
+if [[ ! "$NGINX_ENABLED" =~ ^(true|false)$ ]]; then
+    echo "ERROR: NGINX_ENABLED must be 'true' or 'false'."
+    exit 1
+fi
+
 # Validate FRPC settings.
 if [[ ! "$FRPC_ENABLED" =~ ^(true|false)$ ]]; then
     echo "ERROR: FRPC_ENABLED must be 'true' or 'false'."
@@ -181,7 +191,7 @@ if [ -z "$AVAIL_KB" ] || [ "$AVAIL_KB" -lt "$REQUIRED_KB" ]; then
 fi
 
 # --- 1c. CHECK NGINX PORTS (80, 443) ARE AVAILABLE ---
-if [[ "$NO_NGINX" != "true" ]]; then
+if [[ "$NGINX_ENABLED" == "true" ]]; then
     NGINX_PORTS="80 443"
     for port in $NGINX_PORTS; do
         if ss -tlnp 2>/dev/null | grep -qE ":$port\s"; then
@@ -203,7 +213,7 @@ fi
 if command -v ufw >/dev/null 2>&1; then
     if ufw status | grep -qi "Status: active"; then
         # For nginx mode, ensure there are no DENY/REJECT rules on 80 or 443.
-        if [[ "$NO_NGINX" != "true" ]]; then
+        if [[ "$NGINX_ENABLED" == "true" ]]; then
             if ufw status | awk '$1 == "80/tcp"  && ($2 == "DENY" || $2 == "REJECT") {found=1} END {exit !found}'; then
                 echo "ERROR: Firewall (ufw) is blocking port 80. Please unblock it before running the installer."
                 exit 1
@@ -260,7 +270,7 @@ else
     PKGS="docker.io docker-compose $PKGS"
 fi
 
-if [[ "$NO_NGINX" != "true" ]]; then
+if [[ "$NGINX_ENABLED" == "true" ]]; then
     PKGS="certbot $PKGS"
 fi
 
@@ -295,6 +305,7 @@ EXT_IP=$(curl -s https://api.ipify.org)
 cat <<EOF > .env
 FULLNODE_EXT_IP=$EXT_IP
 FULLNODE_FQDN=$FQDN
+NGINX_ENABLED=$NGINX_ENABLED
 FRPC_ENABLED=$FRPC_ENABLED
 FRPS_SERVER_ADDR=$FRPS_SERVER_ADDR
 FRPS_SERVER_PORT=$FRPS_SERVER_PORT
@@ -332,8 +343,8 @@ localPort = $COTI_FULL_NODE_RPC_LOCAL_PORT
 customDomains = ["$FRPC_CUSTOM_DOMAIN"]
 EOF
 
-# --- 6-8. SSL AND NGINX SETUP (skipped with --no-nginx) ---
-if [[ "$NO_NGINX" != "true" ]]; then
+# --- 6-8. SSL AND NGINX SETUP (skipped when NGINX_ENABLED=false) ---
+if [[ "$NGINX_ENABLED" == "true" ]]; then
     echo "--> Preparing for Let's Encrypt challenge..."
     mkdir -p ./nginx/certbot ./nginx/sites-enabled
 
@@ -418,15 +429,11 @@ fi
 # --- 9. FINAL LAUNCH ---
 # Use start_coti-full-node.sh (sources .env, pulls images, starts services)
 echo "--> Starting up the full node stack..."
-if [[ "$NO_NGINX" == "true" ]]; then
-    ./start_coti-full-node.sh --no-nginx
-else
-    ./start_coti-full-node.sh
-fi
+./start_coti-full-node.sh
 
 echo "====================================================="
 echo " SUCCESS! Your COTI full node is initializing."
-if [[ "$NO_NGINX" == "true" ]]; then
+if [[ "$NGINX_ENABLED" != "true" ]]; then
     echo " Mode: node-only (no nginx/SSL). Access RPC/WS on ports 8545/8546."
 else
     echo " FQDN: https://$FQDN"

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -505,11 +505,28 @@ serverPort = $FRPS_SERVER_PORT
 $FRPC_AUTH_BLOCK
 
 [[proxies]]
-name = "$FRPC_CUSTOM_DOMAIN"
+name = "$FRPC_CUSTOM_DOMAIN-rpc"
 type = "http"
 localIP = "coti-${NETWORK}-full-node"
 localPort = 8545
 customDomains = ["$FRPC_CUSTOM_DOMAIN"]
+locations = ["/rpc"]
+
+[[proxies]]
+name = "$FRPC_CUSTOM_DOMAIN-ws"
+type = "http"
+localIP = "coti-${NETWORK}-full-node"
+localPort = 8546
+customDomains = ["$FRPC_CUSTOM_DOMAIN"]
+locations = ["/ws"]
+
+[[proxies]]
+name = "$FRPC_CUSTOM_DOMAIN-operator"
+type = "http"
+localIP = "coti-${NETWORK}-operator-dashboard"
+localPort = 8090
+customDomains = ["$FRPC_CUSTOM_DOMAIN"]
+locations = ["/operator"]
 EOF
     done
     unset _frpc_toml_pair _frpc_toml_file _frpc_server_addr
@@ -554,6 +571,10 @@ upstream fullnode_6000 {
     server coti-$NETWORK-full-node:6000  max_fails=3 fail_timeout=30s;
 }
 
+upstream operator_dashboard_8090 {
+    server coti-$NETWORK-operator-dashboard:8090  max_fails=3 fail_timeout=30s;
+}
+
 server {
     listen 443 ssl;
     server_name $FQDN;
@@ -583,6 +604,18 @@ server {
         proxy_set_header Host \$host;
         proxy_pass http://fullnode_6000/debug/metrics/prometheus;
     }
+
+    location = /operator {
+        return 301 https://\$host/operator/;
+    }
+
+    location /operator/ {
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_pass http://operator_dashboard_8090/;
+    }
 }
 
 server {
@@ -609,16 +642,16 @@ _w ""
 if [[ "$NGINX_ENABLED" != "true" ]]; then
     _w "  • Mode: ${_B}no Nginx/SSL on this host${_R}"
     if [[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]] && [[ "$FRPC_ENABLED" == "true" ]]; then
-        _w "  • COTI tunnel: public HTTPS/RPC at ${_B}https://${FRPC_CUSTOM_DOMAIN:-$FQDN}${_R} (edge TLS + DNS by COTI; FRPC to this node)"
+        _w "  • COTI tunnel: JSON-RPC ${_B}https://${FRPC_CUSTOM_DOMAIN:-$FQDN}/rpc${_R}, WebSocket ${_U}https://${FRPC_CUSTOM_DOMAIN:-$FQDN}/ws${_R}, operator ${_U}https://${FRPC_CUSTOM_DOMAIN:-$FQDN}/operator/${_R}"
     else
         _w "  • RPC / WS: published on host ports 8545 / 8546 (see docker-compose)"
     fi
 else
-    _w "  • HTTPS: ${_B}https://$FQDN${_R}"
+    _w "  • HTTPS: ${_B}https://$FQDN${_R} (RPC/WS: /rpc /ws; operator dashboard: /operator/)"
 fi
 if [[ "$FRPC_ENABLED" == "true" ]]; then
     _w "  • FRPC: ${_B}enabled${_R} — gateways $FRPS_SERVER_ADDR_1:$FRPS_SERVER_PORT, $FRPS_SERVER_ADDR_2:$FRPS_SERVER_PORT"
-    _w "  • FRPC custom domain (proxy name): ${FRPC_CUSTOM_DOMAIN}"
+    _w "  • FRPC: host ${_B}${FRPC_CUSTOM_DOMAIN}${_R} — ${_U}/rpc${_R} → 8545, ${_U}/ws${_R} → 8546, ${_U}/operator/${_R} → dashboard (frpc: …-rpc, …-ws, …-operator)"
     if [[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]]; then
         _w "  • Inbound firewall: ${_B}not required${_R} for 80/443/7400 from the internet (outbound FRP + local P2P)"
     fi
@@ -626,5 +659,11 @@ else
     _w "  • FRPC: ${_D}disabled${_R} (wizard tunnel: ${_U}--with-frp${_R}; relay only: ${_U}--frpc-enabled=true${_R})"
 fi
 _w "  • Logs: ${_U}docker logs -f coti-$NETWORK-full-node${_R}"
-_w "  • ${_B}Health check page${_R} (this machine): ${_U}http://127.0.0.1:8090${_R} — simple green/red status for support"
+if [[ "$NGINX_ENABLED" == "true" ]]; then
+    _w "  • ${_B}Health check page${_R}: ${_U}https://$FQDN/operator/${_R} (or local ${_U}http://127.0.0.1:8090${_R})"
+elif [[ "$FRPC_ENABLED" == "true" ]] && [[ -n "${FRPC_CUSTOM_DOMAIN:-}" ]]; then
+    _w "  • ${_B}Health check page${_R}: ${_U}https://$FRPC_CUSTOM_DOMAIN/operator/${_R} (or local ${_U}http://127.0.0.1:8090${_R})"
+else
+    _w "  • ${_B}Health check page${_R} (this machine): ${_U}http://127.0.0.1:8090${_R} — simple green/red status for support"
+fi
 _div

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -131,7 +131,6 @@ DOCKER_FULL_NODE_IMAGE_VERSION="${IMAGE:-$DOCKER_FULL_NODE_IMAGE_VERSION}"
 : "${FRPS_SERVER_PORT:=7000}"
 : "${FRPC_CUSTOM_DOMAIN:=}"
 : "${FRPC_AUTH_TOKEN:=}"
-: "${COTI_FULL_NODE_RPC_LOCAL_PORT:=8545}"
 
 # --- ROOT CHECK ---
 if [ "$(id -u)" -ne 0 ]; then
@@ -289,11 +288,6 @@ fi
 
 if [[ ! "$FRPS_SERVER_PORT" =~ ^[0-9]+$ ]] || [ "$FRPS_SERVER_PORT" -lt 1 ] || [ "$FRPS_SERVER_PORT" -gt 65535 ]; then
     printf '%s\n' "${_Y}ERROR:${_R} FRPS_SERVER_PORT must be a valid TCP port (1–65535)."
-    exit 1
-fi
-
-if [[ ! "$COTI_FULL_NODE_RPC_LOCAL_PORT" =~ ^[0-9]+$ ]] || [ "$COTI_FULL_NODE_RPC_LOCAL_PORT" -lt 1 ] || [ "$COTI_FULL_NODE_RPC_LOCAL_PORT" -gt 65535 ]; then
-    printf '%s\n' "${_Y}ERROR:${_R} COTI_FULL_NODE_RPC_LOCAL_PORT must be a valid TCP port (1–65535)."
     exit 1
 fi
 
@@ -482,7 +476,6 @@ FRPS_SERVER_ADDR_2=$FRPS_SERVER_ADDR_2
 FRPS_SERVER_PORT=$FRPS_SERVER_PORT
 FRPC_CUSTOM_DOMAIN=$FRPC_CUSTOM_DOMAIN
 FRPC_AUTH_TOKEN=$FRPC_AUTH_TOKEN
-COTI_FULL_NODE_RPC_LOCAL_PORT=$COTI_FULL_NODE_RPC_LOCAL_PORT
 EOF
 
 # --- 5. CONFIGURE PRIVATE KEY (NODEKEY) ---
@@ -618,7 +611,7 @@ if [[ "$NGINX_ENABLED" != "true" ]]; then
     if [[ "${COTI_TUNNEL_INSTALL:-false}" == "true" ]] && [[ "$FRPC_ENABLED" == "true" ]]; then
         _w "  • COTI tunnel: public HTTPS/RPC at ${_B}https://${FRPC_CUSTOM_DOMAIN:-$FQDN}${_R} (edge TLS + DNS by COTI; FRPC to this node)"
     else
-        _w "  • RPC / WS: published on host ports ${COTI_FULL_NODE_RPC_LOCAL_PORT} / 8546 (see docker-compose)"
+        _w "  • RPC / WS: published on host ports 8545 / 8546 (see docker-compose)"
     fi
 else
     _w "  • HTTPS: ${_B}https://$FQDN${_R}"

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -34,10 +34,10 @@ echo "       Requirements for the installer"
 echo "====================================================="
 echo "1. OS: Ubuntu 24.04 LTS (Certified by COTI)"
 echo "2. Disk space: $DISK_SPACE_REQUIRED GB"
-echo "3. Ports 80 and 443 must be available for Nginx"
+echo "3. Ports 80 and 443 must be available for Nginx (if nginx is not used, skip this requirement)"
 echo "4. Port 7400 must be available"
-echo "5. Firewall must not be blocking ports 80, 443 and 7400"
-echo "6. Iptables must not be blocking port 7400"
+echo "5. Firewall must not be blocking ports 80, 443 and 7400 (if ufw is not used, skip this requirement)"
+echo "6. Iptables must not be blocking port 7400 (if iptables is not used, skip this requirement)"
 echo "====================================================="
 read -p "Press Enter to continue or Ctrl+C to abort" < /dev/tty
 
@@ -61,17 +61,6 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
 fi
 
-# Parse --no-nginx and --staging flags
-NO_NGINX=false
-CERTBOT_STAGING=false
-for arg in "$@"; do
-    if [[ "$arg" == "--no-nginx" ]]; then
-        NO_NGINX=true
-    elif [[ "$arg" == "--staging" ]]; then
-        CERTBOT_STAGING=true
-    fi
-done
-
 # Accept PK and FQDN as positional arguments
 PK="$1"
 FQDN="$2"
@@ -79,6 +68,12 @@ FQDN="$2"
 # Optional FRPC overrides via environment variables or flags.
 for arg in "$@"; do
     case "$arg" in
+        --no-nginx)
+            NO_NGINX=true
+            ;;
+        --staging)
+            CERTBOT_STAGING=true
+            ;;
         --frpc-enabled=*)
             FRPC_ENABLED="${arg#*=}"
             ;;
@@ -257,22 +252,22 @@ elif dpkg -s containerd.io >/dev/null 2>&1; then
     DOCKER_PRESENT=true
 fi
 
+# Detect necessary system dependencies
+PKGS="curl git jq dnsutils"
 if [[ "$DOCKER_PRESENT" == "true" ]]; then
     echo "--> Docker already present, skipping docker.io (avoid containerd.io conflict)"
-    if [[ "$NO_NGINX" == "true" ]]; then
-        apt-get install -y --no-install-recommends curl git jq dnsutils
-    else
-        apt-get install -y --no-install-recommends certbot curl git jq dnsutils
-    fi
 else
-    if [[ "$NO_NGINX" == "true" ]]; then
-        apt-get install -y docker.io docker-compose curl git jq dnsutils
-    else
-        apt-get install -y docker.io docker-compose certbot curl git jq dnsutils
-    fi
+    PKGS="docker.io docker-compose $PKGS"
 fi
 
-# Choose compose command: prefer "docker compose" (v2 plugin) when available
+if [[ "$NO_NGINX" != "true" ]]; then
+    PKGS="certbot $PKGS"
+fi
+
+# Install necessary system dependencies
+apt-get install -y --no-install-recommends $PKGS
+
+# Set the compose command
 if docker compose version >/dev/null 2>&1; then
     DC="docker compose"
 else

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -30,7 +30,7 @@ print_welcome() {
     _w "  4. Clone repository and prepare directory"
     _w "  5. Generate .env and node identity"
     _w "  6. Optional: Nginx + Let's Encrypt (${_Y}off by default${_R}; use ${_U}--nginx${_R} or ${_U}NGINX_ENABLED=true${_R})"
-    _w "  7. Optional: FRPC RPC relay (${_Y}off by default${_R}; use ${_U}--frpc-enabled=true${_R})"
+    _w "  7. Optional: FRPC RPC relay (${_Y}off by default${_R}; use ${_U}--frpc${_R})"
     _w "  8. Start the stack"
     _w ""
     _div
@@ -120,6 +120,12 @@ for arg in "$@"; do
             ;;
         --staging)
             CERTBOT_STAGING=true
+            ;;
+        --frpc)
+            FRPC_ENABLED=true
+            ;;
+        --no-frpc)
+            FRPC_ENABLED=false
             ;;
         --frpc-enabled=*)
             FRPC_ENABLED="${arg#*=}"
@@ -522,7 +528,7 @@ if [[ "$FRPC_ENABLED" == "true" ]]; then
     _w "  • FRPC: ${_B}enabled${_R} — gateways $FRPS_SERVER_ADDR_1:$FRPS_SERVER_PORT, $FRPS_SERVER_ADDR_2:$FRPS_SERVER_PORT"
     _w "  • Public RPC host: ${FRPC_CUSTOM_DOMAIN}"
 else
-    _w "  • FRPC: ${_D}disabled${_R} (enable with --frpc-enabled=true)"
+    _w "  • FRPC: ${_D}disabled${_R} (enable with --frpc)"
 fi
 _w "  • Logs: ${_U}docker logs -f coti-$NETWORK-full-node${_R}"
 _div

--- a/install_coti-full-node.sh
+++ b/install_coti-full-node.sh
@@ -1,21 +1,60 @@
 #!/bin/bash
 set -e # Exit immediately if a command exits with a non-zero status
 
-# present the steps of the installer
-echo "====================================================="
-echo "       COTI Full Node Automated Installer"
-echo "====================================================="
-echo "1. OS validation"
-echo "2. Validate required inputs (PK, FQDN as args)"
-echo "3. Install host dependencies"
-echo "4. Clone/prepare directory"
-echo "5. Generate .env file"
-echo "6. Configure private key (nodekey)"
-echo "7. SSL and Nginx setup (skipped when NGINX_ENABLED=false or with --no-nginx; use --staging for Let's Encrypt staging)"
-echo "8. Final launch"
-echo "====================================================="
-# Read from /dev/tty so prompts work when script is piped (curl | bash) - avoids consuming the script from stdin
-read -p "Press Enter to continue or Ctrl+C to abort" < /dev/tty
+# --- Terminal styling (no-op when stdout is not a TTY) ---
+if [ -t 1 ] && command -v tput >/dev/null 2>&1; then
+    _B=$(tput bold 2>/dev/null || true)
+    _D=$(tput dim 2>/dev/null || true)
+    _U=$(tput smul 2>/dev/null || true)
+    _R=$(tput sgr0 2>/dev/null || true)
+    _C=$(tput setaf 6 2>/dev/null || true)
+    _G=$(tput setaf 2 2>/dev/null || true)
+    _Y=$(tput setaf 3 2>/dev/null || true)
+else
+    _B="" _D="" _U="" _R="" _C="" _G="" _Y=""
+fi
+
+_w() { printf '%s\n' "$*"; }
+_banner_line() { printf '%s\n' "${_C}${_B}$*${_R}"; }
+_div() { printf '%s\n' "${_D}────────────────────────────────────────────────────${_R}"; }
+
+print_welcome() {
+    _div
+    _banner_line "  COTI Full Node — automated installer"
+    _div
+    _w ""
+    _w "${_B}Planned steps${_R}"
+    _w "  1. OS validation"
+    _w "  2. Validate inputs (private key, FQDN)"
+    _w "  3. Install host dependencies (Docker, tools)"
+    _w "  4. Clone repository and prepare directory"
+    _w "  5. Generate .env and node identity"
+    _w "  6. Optional: Nginx + Let's Encrypt (${_Y}off by default${_R}; use ${_U}--nginx${_R} or ${_U}NGINX_ENABLED=true${_R})"
+    _w "  7. Optional: FRPC RPC relay (${_Y}off by default${_R}; use ${_U}--frpc-enabled=true${_R})"
+    _w "  8. Start the stack"
+    _w ""
+    _div
+}
+
+print_requirements() {
+    _div
+    _banner_line "  Requirements"
+    _div
+    _w "  • OS: Ubuntu 24.04 LTS (supported by COTI)"
+    _w "  • Free disk: ${DISK_SPACE_REQUIRED} GB in the install directory"
+    _w "  • Port 7400 available (node P2P)"
+    _w "  • With Nginx/SSL: ports 80 and 443 free; firewall allows 80/443/7400"
+    _w "  • Without Nginx: RPC/WS on local ports (see success message)"
+    _w ""
+    _div
+}
+
+info() { printf '%s\n' "${_C}→${_R} $*"; }
+ok() { printf '%s\n' "${_G}✓${_R} $*"; }
+
+print_welcome
+read -r -p "Press Enter to continue, or Ctrl+C to abort " < /dev/tty || true
+_w ""
 
 # Load installer configuration (if present) so key constants can be customized without editing this script.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
@@ -28,28 +67,24 @@ fi
 # Default values (can be overridden in installer.env)
 : "${DISK_SPACE_REQUIRED:=40}"      # GB
 
-# present the requirements for the installer
-echo "====================================================="
-echo "       Requirements for the installer"
-echo "====================================================="
-echo "1. OS: Ubuntu 24.04 LTS (Certified by COTI)"
-echo "2. Disk space: $DISK_SPACE_REQUIRED GB"
-echo "3. Ports 80 and 443 must be available for Nginx (if nginx is not used, skip this requirement)"
-echo "4. Port 7400 must be available"
-echo "5. Firewall must not be blocking ports 80, 443 and 7400 (if ufw is not used, skip this requirement)"
-echo "6. Iptables must not be blocking port 7400 (if iptables is not used, skip this requirement)"
-echo "====================================================="
-read -p "Press Enter to continue or Ctrl+C to abort" < /dev/tty
+print_requirements
+read -r -p "Press Enter to continue, or Ctrl+C to abort " < /dev/tty || true
+_w ""
 
 _FRPS_SERVER_ADDR_1_FROM_ENV=false
 _FRPS_SERVER_ADDR_2_FROM_ENV=false
-[[ -v FRPS_SERVER_ADDR_1 ]] && _FRPS_SERVER_ADDR_1_FROM_ENV=true
-[[ -v FRPS_SERVER_ADDR_2 ]] && _FRPS_SERVER_ADDR_2_FROM_ENV=true
+# After sourcing installer.env: detect FRPS host vars before := defaults (matches empty assignment)
+if declare -p FRPS_SERVER_ADDR_1 >/dev/null 2>&1; then
+    _FRPS_SERVER_ADDR_1_FROM_ENV=true
+fi
+if declare -p FRPS_SERVER_ADDR_2 >/dev/null 2>&1; then
+    _FRPS_SERVER_ADDR_2_FROM_ENV=true
+fi
 
 : "${DOCKER_FULL_NODE_IMAGE_VERSION:=1.2.0}"
 : "${CLONE_BRANCH:=coti-testnet}"
 : "${NETWORK:=testnet}"
-: "${NGINX_ENABLED:=true}"
+: "${NGINX_ENABLED:=false}"
 : "${FRPC_ENABLED:=false}"
 : "${FRPS_SERVER_ADDR:=}"
 : "${FRPS_SERVER_ADDR_1:=virginia.fullnode.testnet.coti.io}"
@@ -61,25 +96,24 @@ _FRPS_SERVER_ADDR_2_FROM_ENV=false
 
 # --- ROOT CHECK ---
 if [ "$(id -u)" -ne 0 ]; then
-    echo "This script must be run as root."
-    echo
-    echo "Example:"
-    echo '  curl -sL https://fullnode.testnet.coti.io | sudo bash -s -- "0x..." "your.domain"'
+    printf '%s\n' "${_Y}This script must be run as root.${_R}"
+    _w ""
+    _w "Example:"
+    _w '  curl -sL https://fullnode.testnet.coti.io | sudo bash -s -- "0x..." "your.domain"'
     exit 1
 fi
 
-# Accept PK and FQDN as positional arguments
-PK="$1"
-FQDN="$2"
-
+# Split flags from positional arguments (flags may appear before or after PK/FQDN)
 FRPS_SERVER_ADDR_1_EXPLICIT=false
 FRPS_SERVER_ADDR_2_EXPLICIT=false
-
-# Optional FRPC overrides via environment variables or flags.
+POSITIONAL=()
 for arg in "$@"; do
     case "$arg" in
         --no-nginx)
             NGINX_ENABLED=false
+            ;;
+        --nginx)
+            NGINX_ENABLED=true
             ;;
         --nginx-enabled=*)
             NGINX_ENABLED="${arg#*=}"
@@ -110,8 +144,14 @@ for arg in "$@"; do
         --frps-server-port=*)
             FRPS_SERVER_PORT="${arg#*=}"
             ;;
+        *)
+            POSITIONAL+=("$arg")
+            ;;
     esac
 done
+
+PK="${POSITIONAL[0]:-}"
+FQDN="${POSITIONAL[1]:-}"
 
 # Legacy single gateway: apply FRPS_SERVER_ADDR where a region host was not set (installer.env) or overridden (CLI).
 if [ -n "${FRPS_SERVER_ADDR:-}" ]; then
@@ -123,19 +163,21 @@ if [ -n "${FRPS_SERVER_ADDR:-}" ]; then
     fi
 fi
 
-echo "====================================================="
-echo "       COTI Full Node Automated Installer"
-echo "====================================================="
+_div
+_banner_line "  Installing COTI Full Node"
+_div
+_w ""
 
 # --- 0. OS VALIDATION ---
 if [ -f /etc/os-release ]; then
+    # shellcheck source=/dev/null
     . /etc/os-release
     if [[ "$ID" != "ubuntu" ]] || [[ ! "$VERSION_ID" =~ ^24\.04 ]]; then
-        echo "WARNING: This script only supports Ubuntu 24.04 LTS."
-        echo "Detected: $PRETTY_NAME"
-        read -p "Proceed at your own risk? (y/N): " PROCEED < /dev/tty
+        printf '%s\n' "${_Y}Warning:${_R} This script targets Ubuntu 24.04 LTS."
+        printf '%s\n' "Detected: $PRETTY_NAME"
+        read -r -p "Proceed anyway? (y/N): " PROCEED < /dev/tty
         if [[ ! "$PROCEED" =~ ^[yY] ]]; then
-            echo "Aborted."
+            _w "Aborted."
             exit 1
         fi
     fi
@@ -143,9 +185,13 @@ fi
 
 # --- 1. VALIDATE REQUIRED INPUTS (PK, FQDN as args) ---
 if [ -z "$FQDN" ] || [ -z "$PK" ]; then
-    echo "ERROR: PK and FQDN must be passed as arguments."
-    echo "Example:"
-    echo '  curl -sL https://fullnode.testnet.coti.io | sudo bash -s -- "0x..." "your.domain"'
+    printf '%s\n' "${_Y}ERROR:${_R} Private key and FQDN are required."
+    _w ""
+    _w "Example (node only — default):"
+    _w '  curl -sL https://fullnode.testnet.coti.io | sudo bash -s -- "0x..." "your.domain"'
+    _w ""
+    _w "With Nginx + Let's Encrypt:"
+    _w '  ... | sudo bash -s -- "0x..." "your.domain" --nginx'
     exit 1
 fi
 
@@ -154,27 +200,27 @@ PK_CLEAN="${PK#0x}"
 
 # Validate PK: must be exactly 64 hexadecimal characters (32 bytes)
 if [[ ! "$PK_CLEAN" =~ ^[0-9a-fA-F]{64}$ ]]; then
-    echo "ERROR: PK must be a 64-character hex string (32 bytes). Example: 0x1234...abcd"
-    echo "Got ${#PK_CLEAN} characters."
+    printf '%s\n' "${_Y}ERROR:${_R} Private key must be 64 hex characters (32 bytes), with optional 0x prefix."
+    printf '%s\n' "Got ${#PK_CLEAN} hex characters after stripping 0x."
     exit 1
 fi
 
 # Validate FQDN: hostname only (alphanumeric, hyphens, dots); prevents injection
 if [[ ! "$FQDN" =~ ^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$ ]] || [ "${#FQDN}" -gt 253 ]; then
-    echo "ERROR: FQDN must be a valid hostname (letters, numbers, hyphens, dots only; 1-253 chars)."
-    echo "Example: node1.fullnode.testnet.coti.io"
+    printf '%s\n' "${_Y}ERROR:${_R} FQDN must be a valid hostname (letters, numbers, hyphens, dots; 1–253 chars)."
+    _w "Example: node1.fullnode.testnet.coti.io"
     exit 1
 fi
 
 # Validate NGINX_ENABLED.
 if [[ ! "$NGINX_ENABLED" =~ ^(true|false)$ ]]; then
-    echo "ERROR: NGINX_ENABLED must be 'true' or 'false'."
+    printf '%s\n' "${_Y}ERROR:${_R} NGINX_ENABLED must be 'true' or 'false'."
     exit 1
 fi
 
 # Validate FRPC settings.
 if [[ ! "$FRPC_ENABLED" =~ ^(true|false)$ ]]; then
-    echo "ERROR: FRPC_ENABLED must be 'true' or 'false'."
+    printf '%s\n' "${_Y}ERROR:${_R} FRPC_ENABLED must be 'true' or 'false'."
     exit 1
 fi
 
@@ -183,20 +229,23 @@ if [[ "$FRPC_ENABLED" == "true" ]] && [ -z "$FRPC_CUSTOM_DOMAIN" ]; then
 fi
 
 if [[ ! "$FRPS_SERVER_PORT" =~ ^[0-9]+$ ]] || [ "$FRPS_SERVER_PORT" -lt 1 ] || [ "$FRPS_SERVER_PORT" -gt 65535 ]; then
-    echo "ERROR: FRPS_SERVER_PORT must be a valid TCP port (1-65535)."
+    printf '%s\n' "${_Y}ERROR:${_R} FRPS_SERVER_PORT must be a valid TCP port (1–65535)."
     exit 1
 fi
 
 if [[ ! "$COTI_FULL_NODE_RPC_LOCAL_PORT" =~ ^[0-9]+$ ]] || [ "$COTI_FULL_NODE_RPC_LOCAL_PORT" -lt 1 ] || [ "$COTI_FULL_NODE_RPC_LOCAL_PORT" -gt 65535 ]; then
-    echo "ERROR: COTI_FULL_NODE_RPC_LOCAL_PORT must be a valid TCP port (1-65535)."
+    printf '%s\n' "${_Y}ERROR:${_R} COTI_FULL_NODE_RPC_LOCAL_PORT must be a valid TCP port (1–65535)."
     exit 1
 fi
+
+info "Install mode: Nginx/SSL ${_B}${NGINX_ENABLED}${_R} · FRPC relay ${_B}${FRPC_ENABLED}${_R}"
+_w ""
 
 # --- 1b. CHECK INSTALL DIRECTORY (writability + disk space) ---
 INSTALL_DIR="$(pwd)"
 if [ ! -w "$INSTALL_DIR" ]; then
-    echo "ERROR: Cannot write to current directory ($INSTALL_DIR)."
-    echo "Please run the installer from a writable directory (e.g. cd ~ or cd /mnt)."
+    printf '%s\n' "${_Y}ERROR:${_R} Cannot write to current directory ($INSTALL_DIR)."
+    _w "Run the installer from a writable directory (for example cd ~)."
     exit 1
 fi
 
@@ -205,11 +254,10 @@ AVAIL_KB=$(df -P "$INSTALL_DIR" | awk 'NR==2 {print $4}')
 if [ -z "$AVAIL_KB" ] || [ "$AVAIL_KB" -lt "$REQUIRED_KB" ]; then
     if [ -n "$AVAIL_KB" ]; then
         AVAIL_GB=$((AVAIL_KB / 1024 / 1024))
-        echo "ERROR: Insufficient disk space. $INSTALL_DIR is on a partition with only ${AVAIL_GB} GB free. Required: ${DISK_SPACE_REQUIRED} GB."
+        printf '%s\n' "${_Y}ERROR:${_R} Need at least ${DISK_SPACE_REQUIRED} GB free in $INSTALL_DIR (about ${AVAIL_GB} GB available)."
     else
-        echo "ERROR: Unable to determine disk space for $INSTALL_DIR."
+        printf '%s\n' "${_Y}ERROR:${_R} Could not read free disk space for $INSTALL_DIR."
     fi
-    echo "Please run the installer from a partition with enough space (e.g. cd /mnt)."
     exit 1
 fi
 
@@ -218,8 +266,7 @@ if [[ "$NGINX_ENABLED" == "true" ]]; then
     NGINX_PORTS="80 443"
     for port in $NGINX_PORTS; do
         if ss -tlnp 2>/dev/null | grep -qE ":$port\s"; then
-            echo "ERROR: Port $port is already in use. Nginx requires ports 80 and 443 to be available."
-            echo "Free the port or stop the conflicting service before running the installer."
+            printf '%s\n' "${_Y}ERROR:${_R} Port $port is in use. Nginx needs 80 and 443 free."
             exit 1
         fi
     done
@@ -227,7 +274,7 @@ fi
 
 # --- 1e. CHECK PORT 7400 IS AVAILABLE ---
 if ss -tlnp 2>/dev/null | grep -qE "7400\s"; then
-    echo "ERROR: Port 7400 is already in use. Please free the port before running the installer."
+    printf '%s\n' "${_Y}ERROR:${_R} Port 7400 is already in use."
     exit 1
 fi
 
@@ -238,22 +285,22 @@ if command -v ufw >/dev/null 2>&1; then
         # For nginx mode, ensure there are no DENY/REJECT rules on 80 or 443.
         if [[ "$NGINX_ENABLED" == "true" ]]; then
             if ufw status | awk '$1 == "80/tcp"  && ($2 == "DENY" || $2 == "REJECT") {found=1} END {exit !found}'; then
-                echo "ERROR: Firewall (ufw) is blocking port 80. Please unblock it before running the installer."
+                printf '%s\n' "${_Y}ERROR:${_R} ufw is blocking port 80."
                 exit 1
             fi
             if ufw status | awk '$1 == "443/tcp" && ($2 == "DENY" || $2 == "REJECT") {found=1} END {exit !found}'; then
-                echo "ERROR: Firewall (ufw) is blocking port 443. Please unblock it before running the installer."
+                printf '%s\n' "${_Y}ERROR:${_R} ufw is blocking port 443."
                 exit 1
             fi
         fi
 
         # For the node’s UDP/TCP port 7400, also ensure no DENY/REJECT rules.
         if ufw status | awk '$1 == "7400/udp" && ($2 == "DENY" || $2 == "REJECT") {found=1} END {exit !found}'; then
-            echo "ERROR: Firewall (ufw) is blocking port 7400/udp. Please unblock it before running the installer."
+            printf '%s\n' "${_Y}ERROR:${_R} ufw is blocking 7400/udp."
             exit 1
         fi
         if ufw status | awk '$1 == "7400/tcp" && ($2 == "DENY" || $2 == "REJECT") {found=1} END {exit !found}'; then
-            echo "ERROR: Firewall (ufw) is blocking port 7400/tcp. Please unblock it before running the installer."
+            printf '%s\n' "${_Y}ERROR:${_R} ufw is blocking 7400/tcp."
             exit 1
         fi
     fi
@@ -264,13 +311,13 @@ fi
 # exit !found: when blocking found, exit 0 so we run the error block; when not found, exit 1 so we continue
 if command -v iptables >/dev/null 2>&1; then
     if iptables -L -n 2>/dev/null | awk '/dpt:7400/ && ($1 == "DROP" || $1 == "REJECT") {found=1} END {exit !found}'; then
-        echo "ERROR: iptables appears to be blocking port 7400. Please unblock it before running the installer."
+        printf '%s\n' "${_Y}ERROR:${_R} iptables appears to block port 7400."
         exit 1
     fi
 fi
 
 # --- 2. INSTALL HOST DEPENDENCIES ---
-echo "--> Installing necessary system dependencies (Docker, Certbot)..."
+info "Installing system packages..."
 # Ensure package index is up to date before installing dependencies.
 apt-get update -y
 
@@ -288,7 +335,7 @@ fi
 # Detect necessary system dependencies
 PKGS="curl git jq dnsutils"
 if [[ "$DOCKER_PRESENT" == "true" ]]; then
-    echo "--> Docker already present, skipping docker.io (avoid containerd.io conflict)"
+    info "Docker already present — skipping docker.io (avoids containerd.io conflict)"
 else
     PKGS="docker.io docker-compose $PKGS"
 fi
@@ -310,19 +357,19 @@ fi
 # --- 3. CLONE/PREPARE DIRECTORY ---
 # Require a clean directory: no existing clone (avoids old-version conflicts).
 if [ -f "docker-compose.yml" ] || [ -d "coti-full-node" ]; then
-    echo "ERROR: Current directory is not clean for a fresh install."
-    echo "  - Found docker-compose.yml: you may be inside an existing clone."
-    echo "  - Found coti-full-node/: a clone already exists here."
-    echo "Please run the installer from an empty directory."
+    printf '%s\n' "${_Y}ERROR:${_R} Current directory is not clean for a fresh install."
+    _w "  • docker-compose.yml present, or"
+    _w "  • coti-full-node/ already exists"
+    _w "Use an empty directory and run again."
     exit 1
 fi
 
-echo "--> Cloning COTI full-node repository..."
-git clone -b $CLONE_BRANCH https://github.com/coti-io/coti-full-node.git
+info "Cloning coti-full-node (${CLONE_BRANCH})..."
+git clone -b "$CLONE_BRANCH" https://github.com/coti-io/coti-full-node.git
 cd coti-full-node
 
 # --- 4. GENERATE .ENV FILE ---
-echo "--> Generating environment variables..."
+info "Writing .env..."
 EXT_IP=$(curl -s https://api.ipify.org)
 
 cat <<EOF > .env
@@ -340,7 +387,7 @@ COTI_FULL_NODE_RPC_LOCAL_PORT=$COTI_FULL_NODE_RPC_LOCAL_PORT
 EOF
 
 # --- 5. CONFIGURE PRIVATE KEY (NODEKEY) ---
-echo "--> Setting up identity and node keys..."
+info "Writing node key..."
 # Ethereum/Geth based clients read the nodekey from a file
 echo -n "$PK_CLEAN" > ./nodekey
 
@@ -376,29 +423,29 @@ unset _frpc_toml_pair _frpc_toml_file _frpc_server_addr
 
 # --- 6-8. SSL AND NGINX SETUP (skipped when NGINX_ENABLED=false) ---
 if [[ "$NGINX_ENABLED" == "true" ]]; then
-    echo "--> Preparing for Let's Encrypt challenge..."
+    info "Preparing Let's Encrypt HTTP-01 challenge..."
     mkdir -p ./nginx/certbot ./nginx/sites-enabled
 
     # Start temporary nginx-init (profile: setup) - serves only port 80 for ACME challenge
-    echo "--> Starting temporary Nginx to verify domain..."
+    info "Starting temporary Nginx for ACME..."
     $DC --profile setup up -d nginx-init
 
     # --- 7. RUN CERTBOT ---
     CERTBOT_EXTRA=""
     if [[ "$CERTBOT_STAGING" == "true" ]]; then
-        echo "--> Requesting SSL Certificate for $FQDN (Let's Encrypt STAGING - not trusted by browsers)..."
+        info "Requesting certificate for $FQDN (${_Y}Let's Encrypt staging${_R} — not browser-trusted)..."
         CERTBOT_EXTRA="--staging"
     else
-        echo "--> Requesting SSL Certificate for $FQDN..."
+        info "Requesting certificate for $FQDN..."
     fi
     certbot certonly --webroot -w "$(pwd)/nginx/certbot" -d "$FQDN" $CERTBOT_EXTRA --register-unsafely-without-email --agree-tos --non-interactive
 
     # Tear down temporary nginx-init so port 80 is free for main nginx
-    echo "--> Tearing down temporary Nginx..."
+    info "Stopping temporary Nginx..."
     $DC --profile setup down
 
     # --- 8. APPLY FINAL NGINX CONFIG ---
-    echo "--> Applying full HTTPS proxy configurations..."
+    info "Writing Nginx TLS proxy config..."
     cat <<EOF > ./nginx/sites-enabled/fullnode.conf
 
 upstream fullnode_8545 {
@@ -458,23 +505,24 @@ EOF
 fi
 
 # --- 9. FINAL LAUNCH ---
-# Use start_coti-full-node.sh (sources .env, pulls images, starts services)
-echo "--> Starting up the full node stack..."
+info "Starting the full node stack..."
 ./start_coti-full-node.sh
 
-echo "====================================================="
-echo " SUCCESS! Your COTI full node is initializing."
+_w ""
+_div
+ok "COTI full node is starting."
+_w ""
 if [[ "$NGINX_ENABLED" != "true" ]]; then
-    echo " Mode: node-only (no nginx/SSL). Access RPC/WS on ports 8545/8546."
+    _w "  • Mode: ${_B}node only${_R} (no Nginx/SSL in Docker)"
+    _w "  • RPC / WS: published on host ports 8545 / 8546 (see docker-compose)"
 else
-    echo " FQDN: https://$FQDN"
+    _w "  • HTTPS: ${_B}https://$FQDN${_R}"
 fi
 if [[ "$FRPC_ENABLED" == "true" ]]; then
-    echo " FRPC RPC relay: enabled"
-    echo " FRPS gateways: $FRPS_SERVER_ADDR_1:$FRPS_SERVER_PORT, $FRPS_SERVER_ADDR_2:$FRPS_SERVER_PORT"
-    echo " Public RPC domain: ${FRPC_CUSTOM_DOMAIN}"
+    _w "  • FRPC: ${_B}enabled${_R} — gateways $FRPS_SERVER_ADDR_1:$FRPS_SERVER_PORT, $FRPS_SERVER_ADDR_2:$FRPS_SERVER_PORT"
+    _w "  • Public RPC host: ${FRPC_CUSTOM_DOMAIN}"
 else
-    echo " FRPC RPC relay: disabled"
+    _w "  • FRPC: ${_D}disabled${_R} (enable with --frpc-enabled=true)"
 fi
-echo " Use 'docker logs -f coti-$NETWORK-full-node' to view logs."
-echo "====================================================="
+_w "  • Logs: ${_U}docker logs -f coti-$NETWORK-full-node${_R}"
+_div

--- a/installer.env
+++ b/installer.env
@@ -1,15 +1,18 @@
 # Installer configuration for COTI full node
 # You can override these defaults without editing install_coti-full-node.sh.
+#
+# After install, this file in the clone holds packaging defaults (image tag, network).
+# Per-host settings live in .env. start/stop load installer.env first, then .env.
 
 # Minimum free disk space required on the install partition (in GB).
 DISK_SPACE_REQUIRED=90
 
-# Docker image version for the COTI full node.
+# Docker image tag for coti/<network>-full-node. Optional: set IMAGE= to override this value.
 DOCKER_FULL_NODE_IMAGE_VERSION=1.2.0
 
 # Git branch of the coti-full-node repository to clone.
 CLONE_BRANCH=coti-testnet
 
-# Network name used in docker-compose and nginx upstreams.
+# Network label for this installer package (must match docker-compose service names; mainnet builds use mainnet).
 NETWORK=testnet
 

--- a/liveness_coti-full-node.sh
+++ b/liveness_coti-full-node.sh
@@ -1,32 +1,54 @@
 #!/bin/bash
 
-# Ethereum JSON-RPC endpoint (change this to your node's endpoint)
-RPC_URL="http://localhost:8545"
+# Resolve repo directory so this script works regardless of cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Match start_coti-full-node.sh: installer defaults, then host .env.
+if [ -f installer.env ] || [ -f .env ]; then
+    set -a
+    # shellcheck source=/dev/null
+    [ -f installer.env ] && . ./installer.env
+    # shellcheck source=/dev/null
+    [ -f .env ] && . ./.env
+    set +a
+fi
+
+: "${COTI_FULL_NODE_RPC_LOCAL_PORT:=8545}"
+RPC_URL="http://127.0.0.1:${COTI_FULL_NODE_RPC_LOCAL_PORT}"
 
 # Number of checks
 CHECKS=5
 # Interval between checks in seconds
 INTERVAL=10
 
-# Function to get the current block number
-get_block_number() {
-    curl -s -X POST "$RPC_URL" \
+# Return block number as decimal (eth_blockNumber returns hex).
+get_block_number_dec() {
+    local hex raw
+    raw=$(curl -fsS --connect-timeout 5 --max-time 15 -X POST "$RPC_URL" \
         -H "Content-Type: application/json" \
-        --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | \
-        jq -r '.result' | xargs printf "%d\n"
+        --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' 2>/dev/null) || return 1
+    hex=$(printf '%s' "$raw" | jq -r '.result // empty') || return 1
+    if [[ ! "$hex" =~ ^0x[0-9a-fA-F]+$ ]]; then
+        return 1
+    fi
+    echo $((16#${hex#0x}))
 }
 
-# Initial block number
-initial_block=$(get_block_number)
+initial_block=$(get_block_number_dec) || initial_block=""
+if [ -z "$initial_block" ] || ! [[ "$initial_block" =~ ^[0-9]+$ ]]; then
+    echo "Could not read a valid block number from $RPC_URL (is the RPC port up?)."
+    exit 1
+fi
 
 echo "Initial block number: $initial_block"
 
 # Monitor block progression
-for (( i=1; i<=$CHECKS; i++ )); do
-    sleep $INTERVAL
-    new_block=$(get_block_number)
-    echo "Check $i: Block number is $new_block"
-    if [ "$new_block" -gt "$initial_block" ]; then
+for (( i=1; i<=CHECKS; i++ )); do
+    sleep "$INTERVAL"
+    new_block=$(get_block_number_dec) || new_block=""
+    echo "Check $i: Block number is ${new_block:-<unavailable>}"
+    if [ -n "$new_block" ] && [[ "$new_block" =~ ^[0-9]+$ ]] && [ "$new_block" -gt "$initial_block" ]; then
         echo "Block number has progressed. Node is syncing."
         exit 0
     fi
@@ -34,4 +56,3 @@ done
 
 echo "Block number did not change after $CHECKS checks. Node might not be syncing."
 exit 1
-

--- a/liveness_coti-full-node.sh
+++ b/liveness_coti-full-node.sh
@@ -14,8 +14,8 @@ if [ -f installer.env ] || [ -f .env ]; then
     set +a
 fi
 
-: "${COTI_FULL_NODE_RPC_LOCAL_PORT:=8545}"
-RPC_URL="http://127.0.0.1:${COTI_FULL_NODE_RPC_LOCAL_PORT}"
+# RPC/WS are fixed at 8545/8546 on the host (see docker-compose.yml).
+RPC_URL="http://127.0.0.1:8545"
 
 # Number of checks
 CHECKS=5

--- a/operator-dashboard/.dockerignore
+++ b/operator-dashboard/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__
+*.pyc
+.git

--- a/operator-dashboard/Dockerfile
+++ b/operator-dashboard/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-alpine
+
+WORKDIR /app
+COPY app.py .
+
+# Non-root user (read-only filesystem except not needed for this app)
+RUN adduser -D -H -u 1000 appuser && chown -R appuser:appuser /app
+USER appuser
+
+EXPOSE 8090
+ENV PYTHONUNBUFFERED=1
+CMD ["python", "-u", "app.py"]

--- a/operator-dashboard/app.py
+++ b/operator-dashboard/app.py
@@ -6,6 +6,7 @@ Binds inside the container on 0.0.0.0; map host to 127.0.0.1 only in docker-comp
 
 from __future__ import annotations
 
+import html
 import json
 import os
 import socket
@@ -27,6 +28,16 @@ FRPC_ENABLED = os.environ.get("FRPC_ENABLED", "false").lower() == "true"
 FRPC_CUSTOM_DOMAIN = (os.environ.get("FRPC_CUSTOM_DOMAIN") or "").strip()
 FRPS_SERVER_ADDR = (os.environ.get("FRPS_SERVER_ADDR") or os.environ.get("FRPS_SERVER_ADDR_1") or "").strip()
 FRPS_SERVER_PORT = int(os.environ.get("FRPS_SERVER_PORT", "7000") or "7000")
+
+
+def _normalize_dashboard_path(path: str) -> str:
+    """Map /operator and /operator/... to paths seen when served without a reverse-proxy prefix."""
+    if path.startswith("/operator"):
+        rest = path[len("/operator") :]
+        if not rest or rest == "/":
+            return "/"
+        return rest if rest.startswith("/") else f"/{rest}"
+    return path
 
 
 def _rpc(method: str, params: list[Any] | None = None) -> dict[str, Any]:
@@ -335,7 +346,8 @@ def collect_status() -> dict[str, Any]:
                 }
             )
         if FRPC_CUSTOM_DOMAIN:
-            tunnel_url = f"https://{FRPC_CUSTOM_DOMAIN.rstrip('/')}/"
+            base = FRPC_CUSTOM_DOMAIN.rstrip("/")
+            tunnel_url = f"https://{base}/rpc"
             try:
                 ctx = ssl.create_default_context()
                 req = Request(tunnel_url, method="HEAD")
@@ -466,6 +478,7 @@ INDEX_HTML = """<!DOCTYPE html>
 <body>
   <h1>COTI Full Node — Status</h1>
   <p class="sub">Open this page on the same machine where the node runs. It refreshes every 15 seconds.</p>
+  __EXTRA_SUB__
   <div id="app"><div class="banner"><span class="spin">⟳</span> Loading…</div></div>
   <footer>Problems persist? Save this page (or a screenshot) when asking for help.</footer>
   <script>
@@ -485,9 +498,16 @@ INDEX_HTML = """<!DOCTYPE html>
     function escapeHtml(s) {
       return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
     }
+    function apiStatusUrl() {
+      let p = window.location.pathname || '/';
+      if (p.toLowerCase().endsWith('/index.html')) p = p.slice(0, -10) || '/';
+      if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1);
+      if (p === '/' || p === '') return '/api/status';
+      return p + '/api/status';
+    }
     async function load() {
       try {
-        const r = await fetch('/api/status', { cache: 'no-store' });
+        const r = await fetch(apiStatusUrl(), { cache: 'no-store' });
         render(await r.json());
       } catch (e) {
         document.getElementById('app').innerHTML =
@@ -502,6 +522,28 @@ INDEX_HTML = """<!DOCTYPE html>
 """
 
 
+def _extra_sub_html() -> str:
+    blocks: list[str] = []
+    if NGINX_ENABLED and FULLNODE_FQDN:
+        u = f"https://{FULLNODE_FQDN}/operator/"
+        blocks.append(
+            f'<p class="sub">HTTPS (this host): <a href="{html.escape(u)}">{html.escape(u)}</a></p>'
+        )
+    if FRPC_ENABLED and FRPC_CUSTOM_DOMAIN:
+        u = f"https://{FRPC_CUSTOM_DOMAIN.rstrip('/')}/operator/"
+        blocks.append(
+            f'<p class="sub">HTTPS (COTI tunnel): <a href="{html.escape(u)}">{html.escape(u)}</a></p>'
+        )
+    return "\n  ".join(blocks)
+
+
+def _index_html() -> str:
+    return INDEX_HTML.replace("__EXTRA_SUB__", _extra_sub_html())
+
+
+INDEX_HTML_BYTES = _index_html().encode()
+
+
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
@@ -511,8 +553,9 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         path = self.path.split("?", 1)[0]
+        path = _normalize_dashboard_path(path)
         if path in ("/", "/index.html"):
-            body = INDEX_HTML.encode()
+            body = INDEX_HTML_BYTES
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))

--- a/operator-dashboard/app.py
+++ b/operator-dashboard/app.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""
+Local operator status page for COTI full node (non-technical friendly).
+Binds inside the container on 0.0.0.0; map host to 127.0.0.1 only in docker-compose.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import ssl
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+LISTEN_HOST = "0.0.0.0"
+LISTEN_PORT = int(os.environ.get("LISTEN_PORT", "8090"))
+RPC_URL = os.environ.get("RPC_URL", "http://127.0.0.1:8545").rstrip("/")
+RPC_TIMEOUT = float(os.environ.get("RPC_TIMEOUT", "8"))
+FULLNODE_FQDN = (os.environ.get("FULLNODE_FQDN") or "").strip()
+FULLNODE_EXT_IP = (os.environ.get("FULLNODE_EXT_IP") or "").strip()
+NGINX_ENABLED = os.environ.get("NGINX_ENABLED", "false").lower() == "true"
+FRPC_ENABLED = os.environ.get("FRPC_ENABLED", "false").lower() == "true"
+FRPC_CUSTOM_DOMAIN = (os.environ.get("FRPC_CUSTOM_DOMAIN") or "").strip()
+FRPS_SERVER_ADDR = (os.environ.get("FRPS_SERVER_ADDR") or os.environ.get("FRPS_SERVER_ADDR_1") or "").strip()
+FRPS_SERVER_PORT = int(os.environ.get("FRPS_SERVER_PORT", "7000") or "7000")
+
+
+def _rpc(method: str, params: list[Any] | None = None) -> dict[str, Any]:
+    body = json.dumps(
+        {"jsonrpc": "2.0", "method": method, "params": params or [], "id": 1}
+    ).encode()
+    req = Request(
+        f"{RPC_URL}/",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urlopen(req, timeout=RPC_TIMEOUT) as resp:
+        raw = resp.read().decode()
+    return json.loads(raw)
+
+
+def _hex_to_int(h: str | None) -> int | None:
+    if not h or not isinstance(h, str) or not h.startswith("0x"):
+        return None
+    try:
+        return int(h, 16)
+    except ValueError:
+        return None
+
+
+def collect_status() -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "ts": int(time.time()),
+        "rpc_url_internal": RPC_URL,
+        "checks": [],
+    }
+
+    # --- JSON-RPC chain / node ---
+    t0 = time.perf_counter()
+    try:
+        bn = _rpc("eth_blockNumber")
+        latency_ms = round((time.perf_counter() - t0) * 1000, 1)
+        err = bn.get("error")
+        if err:
+            out["checks"].append(
+                {
+                    "id": "rpc",
+                    "label": "Node software responding",
+                    "state": "bad",
+                    "detail": str(err.get("message", err)),
+                }
+            )
+            out["checks"].append(
+                {
+                    "id": "summary",
+                    "label": "Overall",
+                    "state": "bad",
+                    "detail": "The node did not answer on the internal network. It may be stopped or still starting.",
+                }
+            )
+            return out
+        block = _hex_to_int(bn.get("result"))
+        out["checks"].append(
+            {
+                "id": "rpc",
+                "label": "Node software responding",
+                "state": "ok",
+                "detail": f"Last block number: {block if block is not None else bn.get('result')}. "
+                f"Response time about {latency_ms} ms.",
+            }
+        )
+    except (URLError, OSError, TimeoutError, json.JSONDecodeError, ValueError) as e:
+        out["checks"].append(
+            {
+                "id": "rpc",
+                "label": "Node software responding",
+                "state": "bad",
+                "detail": f"No answer from the node ({e!s}). Is Docker running and the full node container up?",
+            }
+        )
+        out["checks"].append(
+            {
+                "id": "summary",
+                "label": "Overall",
+                "state": "bad",
+                "detail": "Fix the node container first; other checks were skipped.",
+            }
+        )
+        return out
+
+    try:
+        peers_raw = _rpc("net_peerCount")
+        peers = _hex_to_int(peers_raw.get("result"))
+        if peers is None:
+            peer_detail = "Could not read peer count."
+            peer_state = "warn"
+        elif peers == 0:
+            peer_detail = (
+                "No peers yet. If the machine just started, wait a few minutes. "
+                "If this stays at zero, check firewall rules for outbound/inbound on port 7400 (P2P)."
+            )
+            peer_state = "warn"
+        else:
+            peer_detail = f"Connected to {peers} peer(s). This is how the node talks to the network."
+            peer_state = "ok"
+        out["checks"].append(
+            {
+                "id": "peers",
+                "label": "Connection to other nodes (P2P)",
+                "state": peer_state,
+                "detail": peer_detail,
+            }
+        )
+    except (URLError, OSError, TimeoutError, json.JSONDecodeError, ValueError) as e:
+        out["checks"].append(
+            {
+                "id": "peers",
+                "label": "Connection to other nodes (P2P)",
+                "state": "warn",
+                "detail": f"Could not read peer count: {e!s}",
+            }
+        )
+
+    try:
+        sync = _rpc("eth_syncing")
+        sr = sync.get("result")
+        if sr is False:
+            out["checks"].append(
+                {
+                    "id": "sync",
+                    "label": "Blockchain sync",
+                    "state": "ok",
+                    "detail": "Caught up with the network (not actively syncing large history).",
+                }
+            )
+        elif isinstance(sr, dict):
+            cur = _hex_to_int(sr.get("currentBlock"))
+            high = _hex_to_int(sr.get("highestBlock"))
+            out["checks"].append(
+                {
+                    "id": "sync",
+                    "label": "Blockchain sync",
+                    "state": "warn",
+                    "detail": f"Still syncing. Local block about {cur}, network head about {high}.",
+                }
+            )
+        else:
+            out["checks"].append(
+                {
+                    "id": "sync",
+                    "label": "Blockchain sync",
+                    "state": "warn",
+                    "detail": "Sync status is unclear from the node.",
+                }
+            )
+    except (URLError, OSError, TimeoutError, json.JSONDecodeError, ValueError) as e:
+        out["checks"].append(
+            {
+                "id": "sync",
+                "label": "Blockchain sync",
+                "state": "warn",
+                "detail": str(e),
+            }
+        )
+
+    try:
+        cid = _rpc("eth_chainId")
+        chain = _hex_to_int(cid.get("result"))
+        out["checks"].append(
+            {
+                "id": "chain",
+                "label": "Network ID",
+                "state": "ok",
+                "detail": f"Chain ID (hex): {cid.get('result')}"
+                + (f" — decimal {chain}" if chain is not None else ""),
+            }
+        )
+    except (URLError, OSError, TimeoutError, json.JSONDecodeError, ValueError):
+        pass
+
+    try:
+        ver = _rpc("web3_clientVersion")
+        out["checks"].append(
+            {
+                "id": "client",
+                "label": "Node version",
+                "state": "ok",
+                "detail": str(ver.get("result", "unknown")),
+            }
+        )
+    except (URLError, OSError, TimeoutError, json.JSONDecodeError, ValueError):
+        pass
+
+    # --- DNS (name points to an address) ---
+    if FULLNODE_FQDN:
+        try:
+            infos = socket.getaddrinfo(FULLNODE_FQDN, None, type=socket.SOCK_STREAM)
+            ips = sorted({x[4][0] for x in infos})
+            dns_detail = f"This machine is configured with hostname “{FULLNODE_FQDN}”. It resolves to: {', '.join(ips)}."
+            if FULLNODE_EXT_IP and FULLNODE_EXT_IP in ips:
+                dns_detail += f" That includes your configured public IP ({FULLNODE_EXT_IP})."
+            elif FULLNODE_EXT_IP:
+                dns_detail += (
+                    f" Your configured public IP is {FULLNODE_EXT_IP}. "
+                    "If you expect them to match, update DNS at your registrar or wait for DNS to update."
+                )
+            out["checks"].append(
+                {
+                    "id": "dns",
+                    "label": "DNS name (hostname)",
+                    "state": "ok",
+                    "detail": dns_detail,
+                }
+            )
+        except OSError as e:
+            out["checks"].append(
+                {
+                    "id": "dns",
+                    "label": "DNS name (hostname)",
+                    "state": "bad",
+                    "detail": f"The name “{FULLNODE_FQDN}” did not resolve ({e!s}). Check DNS settings.",
+                }
+            )
+    else:
+        out["checks"].append(
+            {
+                "id": "dns",
+                "label": "DNS name (hostname)",
+                "state": "warn",
+                "detail": "No FULLNODE_FQDN is set in your environment, so DNS was not checked.",
+            }
+        )
+
+    # --- HTTPS on your domain (only when Nginx + TLS is used) ---
+    if NGINX_ENABLED and FULLNODE_FQDN:
+        url = f"https://{FULLNODE_FQDN}/"
+        try:
+            ctx = ssl.create_default_context()
+            req = Request(url, method="HEAD")
+            with urlopen(req, timeout=12, context=ctx) as resp:
+                code = resp.status
+            ok_code = code < 500 or code in (401, 403, 405)
+            out["checks"].append(
+                {
+                    "id": "https",
+                    "label": "Website / SSL on your domain",
+                    "state": "ok" if ok_code else "warn",
+                    "detail": f"Got HTTP {code} from {url} (TLS certificate verified).",
+                }
+            )
+        except HTTPError as e:
+            ok_code = e.code < 500 or e.code in (401, 403, 405)
+            out["checks"].append(
+                {
+                    "id": "https",
+                    "label": "Website / SSL on your domain",
+                    "state": "ok" if ok_code else "warn",
+                    "detail": f"Server answered with HTTP {e.code} for {url}. TLS is working; path may differ.",
+                }
+            )
+        except (URLError, OSError, TimeoutError) as e:
+            out["checks"].append(
+                {
+                    "id": "https",
+                    "label": "Website / SSL on your domain",
+                    "state": "bad",
+                    "detail": f"Could not open {url} ({e!s}). Check Nginx and certificates.",
+                }
+            )
+    elif FRPC_ENABLED:
+        out["checks"].append(
+            {
+                "id": "https",
+                "label": "Public HTTPS on this machine",
+                "state": "ok",
+                "detail": "You are using the COTI tunnel (FRPC). HTTPS is handled at COTI’s gateway, not on this PC’s Nginx.",
+            }
+        )
+    else:
+        out["checks"].append(
+            {
+                "id": "https",
+                "label": "Public HTTPS on your domain",
+                "state": "warn",
+                "detail": "Nginx with TLS is not enabled in your settings, so a public HTTPS check was skipped.",
+            }
+        )
+
+    # --- FRPC gateway reachability ---
+    if FRPC_ENABLED and FRPS_SERVER_ADDR:
+        try:
+            sock = socket.create_connection((FRPS_SERVER_ADDR, FRPS_SERVER_PORT), timeout=6)
+            sock.close()
+            out["checks"].append(
+                {
+                    "id": "frp_gateway",
+                    "label": "COTI gateway (tunnel)",
+                    "state": "ok",
+                    "detail": f"This machine can reach {FRPS_SERVER_ADDR}:{FRPS_SERVER_PORT} (needed for the RPC tunnel).",
+                }
+            )
+        except OSError as e:
+            out["checks"].append(
+                {
+                    "id": "frp_gateway",
+                    "label": "COTI gateway (tunnel)",
+                    "state": "bad",
+                    "detail": f"Cannot reach {FRPS_SERVER_ADDR}:{FRPS_SERVER_PORT} ({e!s}). "
+                    "Allow outbound traffic in the firewall.",
+                }
+            )
+        if FRPC_CUSTOM_DOMAIN:
+            tunnel_url = f"https://{FRPC_CUSTOM_DOMAIN.rstrip('/')}/"
+            try:
+                ctx = ssl.create_default_context()
+                req = Request(tunnel_url, method="HEAD")
+                with urlopen(req, timeout=12, context=ctx) as resp:
+                    code = resp.status
+                ok_code = code < 500 or code in (401, 403, 405)
+                out["checks"].append(
+                    {
+                        "id": "frp_domain",
+                        "label": "Your tunnel web address",
+                        "state": "ok" if ok_code else "warn",
+                        "detail": f"Got HTTP {code} from {tunnel_url}",
+                    }
+                )
+            except HTTPError as e:
+                ok_code = e.code < 500 or e.code in (401, 403, 405)
+                out["checks"].append(
+                    {
+                        "id": "frp_domain",
+                        "label": "Your tunnel web address",
+                        "state": "ok" if ok_code else "warn",
+                        "detail": f"Got HTTP {e.code} from {tunnel_url}",
+                    }
+                )
+            except (URLError, OSError, TimeoutError) as e:
+                out["checks"].append(
+                    {
+                        "id": "frp_domain",
+                        "label": "Your tunnel web address",
+                        "state": "warn",
+                        "detail": f"Could not verify {tunnel_url} ({e!s}). The tunnel may still be starting.",
+                    }
+                )
+
+    # --- Overall heuristic ---
+    bad = sum(1 for c in out["checks"] if c.get("state") == "bad")
+    warns = sum(1 for c in out["checks"] if c.get("state") == "warn")
+    if bad:
+        summary = (
+            f"{bad} problem(s) to fix. "
+            "Read the red items below or contact COTI support with a screenshot."
+        )
+        sstate = "bad"
+    elif warns:
+        summary = (
+            "No critical errors, but some yellow items need attention or patience (for example first sync)."
+        )
+        sstate = "warn"
+    else:
+        summary = "All automated checks passed."
+        sstate = "ok"
+    out["checks"].insert(
+        0,
+        {"id": "summary", "label": "Overall", "state": sstate, "detail": summary},
+    )
+
+    return out
+
+
+INDEX_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>COTI Full Node — Status</title>
+  <style>
+    :root {
+      --bg: #0f1419;
+      --card: #1a2332;
+      --text: #e7ecf3;
+      --muted: #8b9bb4;
+      --ok: #3ecf8e;
+      --warn: #f5a623;
+      --bad: #ff6b6b;
+      --border: #2d3a4d;
+    }
+    * { box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      margin: 0;
+      padding: 1.25rem;
+      line-height: 1.5;
+      font-size: 1.05rem;
+    }
+    h1 { font-size: 1.5rem; font-weight: 700; margin: 0 0 0.25rem 0; }
+    .sub { color: var(--muted); font-size: 0.95rem; margin-bottom: 1.25rem; }
+    .banner {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 1rem;
+    }
+    .row {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.65rem;
+    }
+    .row h2 {
+      margin: 0 0 0.35rem 0;
+      font-size: 1.1rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .pill {
+      display: inline-block;
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      padding: 0.2rem 0.55rem;
+      border-radius: 999px;
+    }
+    .pill.ok { background: rgba(62, 207, 142, 0.2); color: var(--ok); }
+    .pill.warn { background: rgba(245, 166, 35, 0.2); color: var(--warn); }
+    .pill.bad { background: rgba(255, 107, 107, 0.2); color: var(--bad); }
+    .detail { color: var(--muted); font-size: 0.95rem; margin: 0; }
+    footer { color: var(--muted); font-size: 0.85rem; margin-top: 1.5rem; }
+    .spin { display: inline-block; animation: r 0.9s linear infinite; }
+    @keyframes r { to { transform: rotate(360deg); } }
+  </style>
+</head>
+<body>
+  <h1>COTI Full Node — Status</h1>
+  <p class="sub">Open this page on the same machine where the node runs. It refreshes every 15 seconds.</p>
+  <div id="app"><div class="banner"><span class="spin">⟳</span> Loading…</div></div>
+  <footer>Problems persist? Save this page (or a screenshot) when asking for help.</footer>
+  <script>
+    function pill(state) {
+      const t = state === 'ok' ? 'Good' : state === 'warn' ? 'Attention' : 'Problem';
+      return '<span class="pill ' + state + '">' + t + '</span>';
+    }
+    function render(data) {
+      const checks = data.checks || [];
+      let html = '';
+      for (const c of checks) {
+        html += '<div class="row"><h2>' + pill(c.state) + ' ' + escapeHtml(c.label) + '</h2>';
+        html += '<p class="detail">' + escapeHtml(c.detail) + '</p></div>';
+      }
+      document.getElementById('app').innerHTML = html;
+    }
+    function escapeHtml(s) {
+      return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    }
+    async function load() {
+      try {
+        const r = await fetch('/api/status', { cache: 'no-store' });
+        render(await r.json());
+      } catch (e) {
+        document.getElementById('app').innerHTML =
+          '<div class="banner"><span class="pill bad">Problem</span> Could not load status.</div>';
+      }
+    }
+    load();
+    setInterval(load, 15000);
+  </script>
+</body>
+</html>
+"""
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        # Quiet default logging
+        return
+
+    def do_GET(self) -> None:
+        path = self.path.split("?", 1)[0]
+        if path in ("/", "/index.html"):
+            body = INDEX_HTML.encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+        elif path == "/api/status":
+            data = collect_status()
+            body = json.dumps(data, indent=2).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_error(404, "Not Found")
+
+
+def main() -> None:
+    server = ThreadingHTTPServer((LISTEN_HOST, LISTEN_PORT), Handler)
+    print(f"operator-dashboard listening on {LISTEN_HOST}:{LISTEN_PORT}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/reset_coti-full-node.sh
+++ b/reset_coti-full-node.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Reset full node when node panics with "Head state missing" or database corruption.
-# Preserves nodekey and keystore. Requires full re-sync after running.
+# Preserves nodekey (host file). Drops chain data (Docker named volume) and requires full re-sync after running.
 
 set -e
 
@@ -23,8 +23,8 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
 fi
 
-echo "WARNING: This will delete all node data. The node will need to re-sync from genesis."
-echo "Your nodekey and keystore will be preserved."
+echo "WARNING: This will delete all chain data (Docker volume). The node will need to re-sync from genesis."
+echo "Your ./nodekey file on this host is preserved."
 read -p "Continue? (y/N): " CONFIRM
 if [[ ! "$CONFIRM" =~ ^[yY] ]]; then
     echo "Aborted."
@@ -39,10 +39,8 @@ if [ -f .env ]; then
     set +a
 fi
 
-echo "--> Stopping containers..."
-$DC down 2>/dev/null || true
-
-echo "--> Removing geth directory (preserving nodekey as it is mapped to the container)..."
-rm -rf ./execution/geth/
+ALL_PROFILE_ARGS=(--profile frpc --profile proxy-nginx --profile setup)
+echo "--> Stopping containers and removing chain volume (nodekey on host is preserved)..."
+$DC "${ALL_PROFILE_ARGS[@]}" down -v 2>/dev/null || true
 
 echo "--> Done. Run ./start_coti-full-node.sh to re-init and re-sync."

--- a/reset_coti-full-node.sh
+++ b/reset_coti-full-node.sh
@@ -31,11 +31,15 @@ if [[ ! "$CONFIRM" =~ ^[yY] ]]; then
     exit 1
 fi
 
-# Load .env for docker-compose
-if [ -f .env ]; then
+# installer.env first (packaging defaults), then .env (this host).
+if [ -f installer.env ] || [ -f .env ]; then
     set -a
-    source .env
-    source installer.env
+    # shellcheck source=/dev/null
+    [ -f installer.env ] && . ./installer.env
+    # shellcheck source=/dev/null
+    [ -f .env ] && . ./.env
+    DOCKER_FULL_NODE_IMAGE_VERSION="${IMAGE:-${DOCKER_FULL_NODE_IMAGE_VERSION:-1.2.0}}"
+    export DOCKER_FULL_NODE_IMAGE_VERSION
     set +a
 fi
 

--- a/start_coti-full-node.sh
+++ b/start_coti-full-node.sh
@@ -27,7 +27,7 @@ else
     FRPC_PROFILE_ARG=""
 fi
 
-if [ "${NGINX_ENABLED:-true}" = "true" ]; then
+if [ "${NGINX_ENABLED:-false}" = "true" ]; then
     NGINX_PROFILE_ARG="--profile proxy-nginx"
 else
     NGINX_PROFILE_ARG=""

--- a/start_coti-full-node.sh
+++ b/start_coti-full-node.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-set -x
-set -v
+# Verbose tracing only when debugging (avoids noisy logs and leaking env in production).
+if [ "${COTI_FULL_NODE_DEBUG:-}" = "1" ]; then
+    set -x
+    set -v
+fi
 
 # Choose compose command: prefer "docker compose" (v2 plugin) when available
 if docker compose version >/dev/null 2>&1; then
@@ -10,15 +13,27 @@ else
     DC="docker-compose"
 fi
 
-# Prefer .env from install_coti-full-node.sh when present; otherwise compute at runtime (legacy behavior)
-if [ -f .env ]; then
+# installer.env = installation defaults (e.g. image tag); .env = this host (FQDN, keys, flags). Host values win on overlap.
+if [ -f installer.env ] || [ -f .env ]; then
     set -a
-    source .env
-    source installer.env
+    # shellcheck source=/dev/null
+    [ -f installer.env ] && . ./installer.env
+    # shellcheck source=/dev/null
+    [ -f .env ] && . ./.env
+    DOCKER_FULL_NODE_IMAGE_VERSION="${IMAGE:-${DOCKER_FULL_NODE_IMAGE_VERSION:-1.2.0}}"
+    export DOCKER_FULL_NODE_IMAGE_VERSION
     set +a
 else
-    export FULLNODE_EXT_IP=$(curl -s https://api.ipify.org)
-    export FULLNODE_FQDN=$(dig -x $FULLNODE_EXT_IP +short | head -n 1)
+    if ! FULLNODE_EXT_IP=$(curl -fsS --connect-timeout 10 --max-time 20 https://api.ipify.org); then
+        echo "ERROR: Could not detect public IP (api.ipify.org). Set FULLNODE_EXT_IP or add .env." >&2
+        exit 1
+    fi
+    if [ -z "$FULLNODE_EXT_IP" ]; then
+        echo "ERROR: Public IP lookup returned empty." >&2
+        exit 1
+    fi
+    export FULLNODE_EXT_IP
+    export FULLNODE_FQDN=$(dig -x "$FULLNODE_EXT_IP" +short | head -n 1)
 fi
 
 if [ "${FRPC_ENABLED:-false}" = "true" ]; then

--- a/start_coti-full-node.sh
+++ b/start_coti-full-node.sh
@@ -24,10 +24,10 @@ else
     FRPC_PROFILE_ARG=""
 fi
 
-if [ "${NO_NGINX:-false}" = "true" ]; then
-    NGINX_PROFILE_ARG=""
-else
+if [ "${NGINX_ENABLED:-true}" = "true" ]; then
     NGINX_PROFILE_ARG="--profile proxy-nginx"
+else
+    NGINX_PROFILE_ARG=""
 fi
 
 echo "Ensuring latest docker image version (${DOCKER_FULL_NODE_IMAGE_VERSION:-1.2.0}) is pulled..."

--- a/start_coti-full-node.sh
+++ b/start_coti-full-node.sh
@@ -62,3 +62,9 @@ echo "Node started. Checking liveness..."
 
 echo ""
 echo "Operator status page (same machine): http://127.0.0.1:8090"
+if [ "${NGINX_ENABLED:-false}" = "true" ] && [ -n "${FULLNODE_FQDN:-}" ]; then
+    echo "Operator status page (HTTPS, if TLS is configured): https://${FULLNODE_FQDN}/operator/"
+fi
+if [ "${FRPC_ENABLED:-false}" = "true" ] && [ -n "${FRPC_CUSTOM_DOMAIN:-}" ]; then
+    echo "Operator status page (COTI tunnel): https://${FRPC_CUSTOM_DOMAIN}/operator/"
+fi

--- a/start_coti-full-node.sh
+++ b/start_coti-full-node.sh
@@ -51,8 +51,14 @@ fi
 echo "Ensuring latest docker image version (${DOCKER_FULL_NODE_IMAGE_VERSION:-1.2.0}) is pulled..."
 $DC $NGINX_PROFILE_ARG $FRPC_PROFILE_ARG pull
 
+echo "Building operator status dashboard (local image, quick when cached)..."
+$DC $NGINX_PROFILE_ARG $FRPC_PROFILE_ARG build coti-testnet-operator-dashboard
+
 echo "Starting COTI full node services..."
 $DC $NGINX_PROFILE_ARG $FRPC_PROFILE_ARG up -d
 
 echo "Node started. Checking liveness..."
 ./liveness_coti-full-node.sh
+
+echo ""
+echo "Operator status page (same machine): http://127.0.0.1:8090"

--- a/start_coti-full-node.sh
+++ b/start_coti-full-node.sh
@@ -24,19 +24,17 @@ else
     FRPC_PROFILE_ARG=""
 fi
 
-echo "Ensuring latest docker image version (${DOCKER_FULL_NODE_IMAGE_VERSION:-1.2.0}) is pulled..."
-if [[ "$1" == "--no-nginx" ]]; then
-    $DC $FRPC_PROFILE_ARG pull
+if [ "${NO_NGINX:-false}" = "true" ]; then
+    NGINX_PROFILE_ARG=""
 else
-    $DC --profile proxy-nginx $FRPC_PROFILE_ARG pull
+    NGINX_PROFILE_ARG="--profile proxy-nginx"
 fi
 
+echo "Ensuring latest docker image version (${DOCKER_FULL_NODE_IMAGE_VERSION:-1.2.0}) is pulled..."
+$DC $NGINX_PROFILE_ARG $FRPC_PROFILE_ARG pull
+
 echo "Starting COTI full node services..."
-if [[ "$1" == "--no-nginx" ]]; then
-    $DC $FRPC_PROFILE_ARG up -d
-else
-    $DC --profile proxy-nginx $FRPC_PROFILE_ARG up -d
-fi
+$DC $NGINX_PROFILE_ARG $FRPC_PROFILE_ARG up -d
 
 echo "Node started. Checking liveness..."
 ./liveness_coti-full-node.sh

--- a/start_coti-full-node.sh
+++ b/start_coti-full-node.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -x
+set -v
+
 # Choose compose command: prefer "docker compose" (v2 plugin) when available
 if docker compose version >/dev/null 2>&1; then
     DC="docker compose"

--- a/stop_coti-full-node.sh
+++ b/stop_coti-full-node.sh
@@ -7,11 +7,15 @@ else
     DC="docker-compose"
 fi
 
-# Load .env if present (needed for docker-compose variable substitution)
-if [ -f .env ]; then
+# installer.env first (packaging defaults), then .env (this host).
+if [ -f installer.env ] || [ -f .env ]; then
     set -a
-    source .env
-    source installer.env
+    # shellcheck source=/dev/null
+    [ -f installer.env ] && . ./installer.env
+    # shellcheck source=/dev/null
+    [ -f .env ] && . ./.env
+    DOCKER_FULL_NODE_IMAGE_VERSION="${IMAGE:-${DOCKER_FULL_NODE_IMAGE_VERSION:-1.2.0}}"
+    export DOCKER_FULL_NODE_IMAGE_VERSION
     set +a
 fi
 

--- a/stop_coti-full-node.sh
+++ b/stop_coti-full-node.sh
@@ -15,4 +15,6 @@ if [ -f .env ]; then
     set +a
 fi
 
-sudo $DC down
+# Enable every compose profile so `down` stops optional stacks too (frpc, nginx, nginx-init/setup).
+ALL_PROFILE_ARGS=(--profile frpc --profile proxy-nginx --profile setup)
+$DC "${ALL_PROFILE_ARGS[@]}" down


### PR DESCRIPTION
Use container root free-space as a fallback when DockerRootDir is reported logically but is not exposed on the host path, as happens on WSL with Docker Desktop.